### PR TITLE
add more usage flag for  DRM_FORMAT_ABGR2101010

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -101,6 +101,9 @@ static int i915_add_combinations(struct driver *drv)
 
 	/* Android CTS tests require this. */
 	drv_add_combination(drv, DRM_FORMAT_BGR888, &metadata, BO_USE_SW_MASK);
+#ifdef USE_GRALLOC1
+	drv_modify_combination(drv, DRM_FORMAT_ABGR2101010, &metadata, BO_USE_SW_MASK);
+#endif
 
 	/*
 	 * R8 format is used for Android's HAL_PIXEL_FORMAT_BLOB and is used for JPEG snapshots


### PR DESCRIPTION
The DRM_FORMAT_ABGR2101010 format will be used by Android Media
framework for software codec of AV1Hdr, and the usage flag request
as:
 BO_USE_SW_READ_RARELY
 BO_USE_SW_READ_OFTEN
 BO_USE_SW_WRITE_RARELY
 BO_USE_SW_WRITE_OFTEN

Tracked-On: OAM-95578
Signed-off-by: Yang, Dong <dong.yang@intel.com>