### PR TITLE
INTERNAL: Fix unsupported format issue for camera preview

### DIFF
--- a/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
@@ -16,6 +16,10 @@
 #include "cros_gralloc/gralloc4/CrosGralloc4Utils.h"
 #include "helpers.h"
 
+#ifdef USE_GRALLOC1
+#include "cros_gralloc/i915_private_android_types.h"
+#endif
+
 using aidl::android::hardware::graphics::common::BlendMode;
 using aidl::android::hardware::graphics::common::Dataspace;
 using aidl::android::hardware::graphics::common::PlaneLayout;
@@ -147,10 +151,13 @@ Return<Error> CrosGralloc4Mapper::validateBufferSize(void* rawHandle,
     PixelFormat crosHandleFormat = static_cast<PixelFormat>(crosHandle->droid_format);
 #ifdef USE_GRALLOC1
     int32_t yuvFormat = static_cast<int32_t>(descriptor.format);
-    if (descriptor.format != crosHandleFormat && yuvFormat != crosHandle->droid_format) {
+    if (descriptor.format != crosHandleFormat && yuvFormat != crosHandle->droid_format &&
+        !(descriptor.format == PixelFormat::YCBCR_420_888 &&
+            crosHandle->droid_format == HAL_PIXEL_FORMAT_NV12)) {
         drv_log("Failed to validateBufferSize. Format mismatch.\n");
 #else
     if (descriptor.format != crosHandleFormat) {
+        drv_log("Failed to validateBufferSize. Format mismatch.\n");
 #endif
         return Error::BAD_BUFFER;
     }


### PR DESCRIPTION
Camera preview use YCbCr, and will be converted to resolved format
NV12. NV12 is one private defined format. So the descriptor.format
is not same with crosHandle->droid_format. Suppress the check here.

Tracked-On: OAM-95595
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>