### PR TITLE
INTERNAL: Fix CtsNNAPITestCases failures

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -198,6 +198,9 @@ static int i915_align_dimensions(struct bo *bo, uint32_t tiling, uint32_t *strid
 
 	*aligned_height = ALIGN(*aligned_height, vertical_alignment);
 	if (i915->gen > 3) {
+#ifdef USE_GRALLOC1
+		if(DRM_FORMAT_R8 != bo->meta.format)
+#endif
 		*stride = ALIGN(*stride, horizontal_alignment);
 	} else {
 		while (*stride > horizontal_alignment)


### PR DESCRIPTION
For DRM_FORMAT_R8, we don't need align the stride. This
change could help fix allocator issues in CtsNNAPITestCases.

Tracked-On: OAM-95685
Signed-off-by: Ren Chenglei chenglei.ren@intel.com