### PR TITLE
INTERNAL: Fix CtsHardwareTestCases failures

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -112,6 +112,7 @@ static int i915_add_combinations(struct driver *drv)
 	drv_add_combination(drv, DRM_FORMAT_BGR888, &metadata, BO_USE_SW_MASK);
 #ifdef USE_GRALLOC1
 	drv_modify_combination(drv, DRM_FORMAT_ABGR2101010, &metadata, BO_USE_SW_MASK);
+	drv_add_combination(drv, DRM_FORMAT_RGB888, &metadata, BO_USE_SW_MASK);
 #endif
 
 	/*


### PR DESCRIPTION
Add BO_USE_SW_MASK usage to DRM_FORMAT_RGB888 format,
this is required by Android R CTS.

Test: android.hardware.cts.HardwareBufferTest#testCreate

Tracked-On: OAM-95726
Signed-off-by: Ren Chenglei chenglei.ren@intel.com