### PR TITLE
INTERNAL: Refine importBuffer & freeBuffer

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.h
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.h
@@ -216,12 +216,6 @@ class CrosGralloc1 : public gralloc1_device_t
 		return getAdapter(device)->importBuffer(rawHandle, outBuffer);
 	}
 
-	int32_t freeBuffer(void *freeBuffer);
-	static int32_t freeBufferHook(gralloc1_device_t *device, void *freeBuffer)
-	{
-		return getAdapter(device)->freeBuffer(freeBuffer);
-	}
-
 	int32_t getProducerUsage(buffer_handle_t buffer,
 				 uint64_t * /*gralloc1_producer_usage_t*/ outUsage);
 	static int32_t getProducerUsageHook(gralloc1_device_t *device, buffer_handle_t buffer,

--- a/cros_gralloc/i915_private_android_types.h
+++ b/cros_gralloc/i915_private_android_types.h
@@ -64,7 +64,6 @@ enum { GRALLOC1_FUNCTION_SET_MODIFIER = 101,
        GRALLOC1_FUNCTION_GET_PRIME = 103,
        GRALLOC1_FUNCTION_SET_INTERLACE = 104,
        GRALLOC1_FUNCTION_SET_PROTECTIONINFO = 105,
-       GRALLOC1_FUNCTION_FREE_BUFFER = 106,
        GRALLOC1_LAST_CUSTOM = 500 };
 
 typedef int32_t /*gralloc1_error_t*/ (*GRALLOC1_PFN_SET_MODIFIER)(
@@ -81,9 +80,6 @@ typedef int32_t /*gralloc1_error_t*/ (*GRALLOC1_PFN_SET_INTERLACE)(
 
 typedef int32_t /*gralloc1_error_t*/ (*GRALLOC1_PFN_SET_PROTECTIONINFO)(
         gralloc1_device_t *device, buffer_handle_t buffer, uint32_t protection_info);
-
-typedef int32_t /*gralloc1_error_t*/ (*GRALLOC1_PFN_FREE_BUFFER)(
-	gralloc1_device_t *device, void *freeBuffer);
 
 typedef union intel_protection_info_type_t {
        uint32_t value;


### PR DESCRIPTION
1. native_handle_* need native_handle_t instead of
   buffer_handle_t, this conflicts with mapper 2.0
   release function
2. importBuffer call native_handle_clone, which will
   have "malloc", then we need use "free" by
   native_handle_delete in case of memory leak, which
   is called in private defined API freeBuffer
3. We should use Android official define API release
   instead of private defined API freeBuffer; so we
   need remove native_handle_clone in importBuffer
   and use release directly

Tracked-On: OAM-96807
Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>