### PR TITLE
INTERNAL: fix of suspend/resume issue

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -453,17 +453,6 @@ int32_t CrosGralloc1::release(buffer_handle_t bufferHandle)
 		return GRALLOC1_ERROR_BAD_HANDLE;
 	}
 
-	ret = native_handle_close(bufferHandle);
-	if (ret) {
-		drv_log("Failed to close handle, bad handle.\n");
-		return GRALLOC1_ERROR_BAD_HANDLE;
-	}
-
-	ret = native_handle_delete((native_handle_t*)bufferHandle);
-	if (ret) {
-		drv_log("Failed to delete handle, bad handle.\n");
-		return GRALLOC1_ERROR_BAD_HANDLE;
-	}
 
 	return GRALLOC1_ERROR_NONE;
 }


### PR DESCRIPTION
Inside the release function (CrosGralloc1::release())
native_handle_close() and native_handle_delete() functions are
getting called after driver release function call (driver->release()).
In driver release function these are already cleaned up.
Inside driver release function native_handle_close() is
called  inside destructor of cros_gralloc_buffer.

Tracked-On: OAM-97019
Signed-off-by: Kaushlendra Kumar <kaushalendra.kumar@intel.com>