### PR TITLE
INTERNAL: Fix Skipping unsupported combination format error for virti…

### DIFF
--- a/virtio_gpu.c
+++ b/virtio_gpu.c
@@ -95,6 +95,8 @@ static uint32_t translate_format(uint32_t drm_fourcc)
 	case DRM_FORMAT_YVU420:
 	case DRM_FORMAT_YVU420_ANDROID:
 		return VIRGL_FORMAT_YV12;
+	case DRM_FORMAT_R16:
+		return VIRGL_FORMAT_R16_UNORM;
 	default:
 		return 0;
 	}


### PR DESCRIPTION
…o-gpu CiV

Add DRM_FORMAT_R16 format support in virtio backend.

Tracked-On: OAM-98171
Signed-off-by: Zheng Yazhou <yazhoux.zheng@intel.com>