### PR TITLE
INTERNAL: fix invalid mutex issue

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -125,6 +125,7 @@ namespace android
 static CrosGralloc1 *pCrosGralloc1 = NULL;
 static uint32_t ref_count = 0;
 //static SpinLock global_lock_;
+static std::mutex global_mutex_;
 
 CrosGralloc1::CrosGralloc1()
 {
@@ -749,7 +750,7 @@ int CrosGralloc1::HookDevOpen(const struct hw_module_t *mod, const char *name,
 	}
 
 	//ScopedSpinLock lock(global_lock_);
-	std::lock_guard<std::mutex> lock(std::mutex);
+	std::lock_guard<std::mutex> lock(global_mutex_);
 	ref_count++;
 
 	if (pCrosGralloc1 != NULL) {
@@ -779,7 +780,7 @@ int CrosGralloc1::HookDevOpen(const struct hw_module_t *mod, const char *name,
 int CrosGralloc1::HookDevClose(hw_device_t * /*dev*/)
 {
 	//ScopedSpinLock lock(global_lock_);
-	std::lock_guard<std::mutex> lock(std::mutex);
+	std::lock_guard<std::mutex> lock(global_mutex_);
 	if (ref_count > 0) {
 		ref_count--;
 	}


### PR DESCRIPTION
invalid mutex result in variable of ref_count cannot be protected
property, trigger refree crash during media CTS.

Tracked-On: OAM-99957
Signed-off-by: Yang, Dong <dong.yang@intel.com>