### PR TITLE
Add getResourceId interface to get resource id

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -200,7 +200,7 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	}
 
 	num_bytes = sizeof(struct cros_gralloc_handle);
-	num_bytes += (descriptor->name.size() + 1);
+	num_bytes += (descriptor->name.size() + 1 + 4);
 	/*
 	 * Ensure that the total number of bytes is a multiple of sizeof(int) as
 	 * native_handle_clone() copies data based on hnd->base.numInts.
@@ -257,6 +257,8 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 
 	name = (char *)(&hnd->base.data[hnd->name_offset]);
 	snprintf(name, descriptor->name.size() + 1, "%s", descriptor->name.c_str());
+	char* res_id = (char *)(&hnd->base.data[hnd->name_offset]) + strlen(name) + 1;
+	memcpy(res_id, &bo->resource_id, sizeof(uint32_t));
 
 	id = drv_bo_get_plane_handle(bo, 0).u32;
 	auto buffer = new cros_gralloc_buffer(id, bo, hnd, hnd->fds[hnd->num_planes],

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -231,6 +231,8 @@ gralloc1_function_pointer_t CrosGralloc1::doGetFunction(int32_t intDescriptor)
 		return asFP<GRALLOC1_PFN_GET_TRANSPORT_SIZE>(getTransportSizeHook);
 	case GRALLOC1_FUNCTION_IMPORT_BUFFER:
 		return asFP<GRALLOC1_PFN_IMPORT_BUFFER>(importBufferHook);
+	case GRALLOC1_FUNCTION_GET_RESOURCE_ID:
+		return asFP<GRALLOC1_PFN_GET_RESOURCE_ID>(getResourceIdHook);
 	case GRALLOC1_FUNCTION_INVALID:
 		drv_log("Invalid function descriptor");
 		return nullptr;
@@ -371,6 +373,19 @@ int32_t CrosGralloc1::importBuffer(const buffer_handle_t rawHandle, buffer_handl
 	}
 
 	*outBuffer = rawHandle;
+	return GRALLOC1_ERROR_NONE;
+}
+
+int32_t CrosGralloc1::getResourceId(const buffer_handle_t rawHandle, uint32_t *resource_id)
+{
+	auto hnd = cros_gralloc_convert_handle(rawHandle);
+	if (!hnd) {
+		drv_log("Invalid handle.\n");
+		return -EINVAL;
+	}
+	char* name = (char *)(&hnd->base.data[hnd->name_offset]);
+	char* res_id = (char *)(&hnd->base.data[hnd->name_offset]) + strlen(name) + 1;
+	memcpy(resource_id, res_id, sizeof(uint32_t));
 	return GRALLOC1_ERROR_NONE;
 }
 

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.h
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.h
@@ -209,6 +209,13 @@ class CrosGralloc1 : public gralloc1_device_t
 		return getAdapter(device)->getTransportSize(buffer, outNumFds, outNumInts);
 	}
 
+	int32_t getResourceId(const buffer_handle_t rawHandle, uint32_t *resource_id);
+	static int32_t getResourceIdHook(gralloc1_device_t *device, const buffer_handle_t rawHandle,
+					uint32_t *resource_id)
+	{
+		return getAdapter(device)->getResourceId(rawHandle, resource_id);
+	}
+
 	int32_t importBuffer(const buffer_handle_t rawHandle, buffer_handle_t *outBuffer);
 	static int32_t importBufferHook(gralloc1_device_t *device, const buffer_handle_t rawHandle,
 					buffer_handle_t *outBuffer)

--- a/cros_gralloc/i915_private_android_types.h
+++ b/cros_gralloc/i915_private_android_types.h
@@ -64,6 +64,7 @@ enum { GRALLOC1_FUNCTION_SET_MODIFIER = 101,
        GRALLOC1_FUNCTION_GET_PRIME = 103,
        GRALLOC1_FUNCTION_SET_INTERLACE = 104,
        GRALLOC1_FUNCTION_SET_PROTECTIONINFO = 105,
+       GRALLOC1_FUNCTION_GET_RESOURCE_ID = 106,
        GRALLOC1_LAST_CUSTOM = 500 };
 
 typedef int32_t /*gralloc1_error_t*/ (*GRALLOC1_PFN_SET_MODIFIER)(
@@ -80,6 +81,10 @@ typedef int32_t /*gralloc1_error_t*/ (*GRALLOC1_PFN_SET_INTERLACE)(
 
 typedef int32_t /*gralloc1_error_t*/ (*GRALLOC1_PFN_SET_PROTECTIONINFO)(
         gralloc1_device_t *device, buffer_handle_t buffer, uint32_t protection_info);
+
+typedef int32_t /*gralloc1_error_t*/ (*GRALLOC1_PFN_GET_RESOURCE_ID)(
+        gralloc1_device_t* device, const buffer_handle_t rawHandle,
+        uint32_t* resource_id);
 
 typedef union intel_protection_info_type_t {
        uint32_t value;

--- a/drv_priv.h
+++ b/drv_priv.h
@@ -35,6 +35,7 @@ struct bo {
 	bool is_test_buffer;
 	union bo_handle handles[DRV_MAX_PLANES];
 	void *priv;
+	uint32_t resource_id;
 };
 
 struct format_metadata {

--- a/virtio_gpu.c
+++ b/virtio_gpu.c
@@ -496,6 +496,7 @@ static int virtio_virgl_bo_create(struct bo *bo, uint32_t width, uint32_t height
 	for (uint32_t plane = 0; plane < bo->meta.num_planes; plane++)
 		bo->handles[plane].u32 = res_create.bo_handle;
 
+	bo->resource_id = res_create.res_handle;
 	return 0;
 }
 


### PR DESCRIPTION
While android boot with VirtIO, rdp server will send
frame buffer's reource id instead of frame buffer
to rdp client, so add getResourceId interface to
get resource id corresponding to buffer_handle_t.

Signed-off-by: Li, HaihongX <haihongx.li@intel.com>