### PR TITLE
If is not kmsro mode, only destroy driver once

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -33,6 +33,9 @@ cros_gralloc_driver::~cros_gralloc_driver()
 	if (drv_kms_) {
 		int fd = drv_get_fd(drv_kms_);
 		drv_destroy(drv_kms_);
+		if (!is_kmsro_enabled()) {
+			drv_render_ = nullptr;
+		}
 		drv_kms_ = nullptr;
 		close(fd);
 	}
@@ -68,6 +71,9 @@ int32_t cros_gralloc_driver::init()
 	if (drv_kms_) {
 		int fd = drv_get_fd(drv_kms_);
 		drv_destroy(drv_kms_);
+		if (!is_kmsro_enabled()) {
+			drv_render_ = nullptr;
+		}
 		drv_kms_ = nullptr;
 		close(fd);
 	}


### PR DESCRIPTION
The drv_kms_ == drv_render_ when not in kmsro mode.
Then only destroy driver once to avoid crash.

Tracked-On: OAM-100133
Signed-off-by: HeYue <yue.he@intel.com>