### PR TITLE
To reduce GPU bandwidth,RBC(Render Buffer Compression) Support

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -17,6 +17,7 @@
 
 #ifdef USE_GRALLOC1
 #include "i915_private_android.h"
+#include "cros_gralloc/i915_private_android_types.h"
 #endif
 
 cros_gralloc_driver::cros_gralloc_driver() : drv_(nullptr)
@@ -158,6 +159,16 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	}
 
 #ifdef USE_GRALLOC1
+	if (resolved_format == DRM_FORMAT_XRGB8888 ||
+		resolved_format == DRM_FORMAT_XBGR8888 ||
+		resolved_format == DRM_FORMAT_ARGB8888 ||
+		resolved_format == DRM_FORMAT_ABGR8888) {
+		struct cros_gralloc_buffer_descriptor* descriptor_ccs =
+			const_cast<struct cros_gralloc_buffer_descriptor*>(descriptor);
+		if (descriptor_ccs->use_flags & BO_USE_SCANOUT)	{
+			descriptor_ccs->modifier = I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS;
+		}
+	}
 	if (descriptor->modifier == 0) {
 		bo = drv_bo_create(drv_, descriptor->width, descriptor->height, resolved_format,
 				   use_flags);

--- a/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
@@ -512,6 +512,13 @@ Return<void> CrosGralloc4Mapper::get(cros_gralloc_handle_t crosHandle,
             planeLayout.widthInSamples = crosHandle->width / planeLayout.horizontalSubsampling;
             planeLayout.heightInSamples = crosHandle->height / planeLayout.verticalSubsampling;
         }
+        if (crosHandle->format_modifier == I915_FORMAT_MOD_Y_TILED_CCS ||
+            crosHandle->format_modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS) {
+            planeLayouts.resize(planeLayouts.size() + 1);
+            PlaneLayout& planeLayout = planeLayouts[planeLayouts.size() - 1];
+            planeLayout.offsetInBytes = crosHandle->offsets[planeLayouts.size() - 1];
+            planeLayout.strideInBytes = crosHandle->strides[planeLayouts.size() - 1];
+        }
 
         status = android::gralloc4::encodePlaneLayouts(planeLayouts, &encodedMetadata);
     } else if (metadataType == android::gralloc4::MetadataType_Crop) {

--- a/cros_gralloc/i915_private_android_types.h
+++ b/cros_gralloc/i915_private_android_types.h
@@ -12,6 +12,7 @@
 
 #include <hardware/gralloc1.h>
 
+#define I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS fourcc_mod_code(INTEL, 6)
 enum { HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL = 0x100,
        HAL_PIXEL_FORMAT_NV12_LINEAR_INTEL = 0x101,
        HAL_PIXEL_FORMAT_YCrCb_422_H_INTEL = 0x102,

--- a/i915.c
+++ b/i915.c
@@ -22,6 +22,7 @@
 
 #ifdef USE_GRALLOC1
 #include "i915_private.h"
+#include "cros_gralloc/i915_private_android_types.h"
 #endif
 
 #define I915_CACHELINE_SIZE 64
@@ -306,6 +307,8 @@ static int i915_bo_compute_metadata(struct bo *bo, uint32_t width, uint32_t heig
 	static const uint64_t modifier_order[] = {
 		I915_FORMAT_MOD_Y_TILED,
 		I915_FORMAT_MOD_X_TILED,
+		I915_FORMAT_MOD_Y_TILED_CCS,
+		I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS,
 		DRM_FORMAT_MOD_LINEAR,
 	};
 	uint64_t modifier;
@@ -332,6 +335,7 @@ static int i915_bo_compute_metadata(struct bo *bo, uint32_t width, uint32_t heig
 #ifdef USE_GRALLOC1
 	case I915_FORMAT_MOD_Yf_TILED:
 	case I915_FORMAT_MOD_Yf_TILED_CCS:
+	case I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS:
 #endif
 		bo->meta.tiling = I915_TILING_Y;
 		break;
@@ -391,6 +395,33 @@ static int i915_bo_compute_metadata(struct bo *bo, uint32_t width, uint32_t heig
 
 		bo->meta.num_planes = 2;
 		bo->meta.total_size = offset;
+	} else if (modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS) {
+		/*
+		 * considering only 128 byte compression and one cache line of
+		 * aux buffer(64B) contains compression status of 4-Y tiles.
+		 * Which is 4 * (128B * 32L).
+		 * line stride(bytes) is 4 * 128B
+		 * and tile stride(lines) is 32L
+		 */
+		uint32_t stride = ALIGN(drv_stride_from_format(format, width, 0), 512);
+		height = ALIGN(drv_height_from_format(format, height, 0), 32);
+
+		bo->meta.strides[0] = stride;
+		/* size calculation and alignment are 64KB aligned
+		 * size as per spec
+		 */
+		bo->meta.sizes[0] = ALIGN(stride * height, 65536);
+		bo->meta.offsets[0] = 0;
+		/* Aux buffer is linear and page aligned. It is placed after
+		 * other planes and aligned to main buffer stride.
+		 */
+		bo->meta.strides[1] = bo->meta.strides[0] / 8;
+		/* Aligned to page size */
+		bo->meta.sizes[1] = ALIGN(bo->meta.sizes[0] / 256, getpagesize());
+		bo->meta.offsets[1] = bo->meta.sizes[0];
+		/* Total number of planes & sizes */
+		bo->meta.num_planes = 2;
+		bo->meta.total_size = bo->meta.sizes[0] + bo->meta.sizes[1];
 	} else {
 		i915_bo_from_format(bo, width, height, format);
 	}


### PR DESCRIPTION
If buffer is using for BO_USE_SCANOUT and format is one
of the DRM_FORMAT_XRGB8888,DRM_FORMAT_XBGR8888,
DRM_FORMAT_ARGB8888 and DRM_FORMAT_ABGR8888,set modifier
with I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS to enable RBC
support.And return ccs plane layout offset and stride
data,becasue these are needed in hwcomposer and kernel.

Tracked-On: OAM-101691
Signed-off-by: Li, HaihongX <haihongx.li@intel.com>