### PR TITLE
Enable the hw codec in SRIOV mode

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.h
+++ b/cros_gralloc/cros_gralloc_driver.h
@@ -20,7 +20,7 @@ class cros_gralloc_driver
 	~cros_gralloc_driver();
 
 	int32_t init();
-	bool is_supported(const struct cros_gralloc_buffer_descriptor *descriptor);
+	bool is_supported(struct cros_gralloc_buffer_descriptor *descriptor);
 	int32_t allocate(const struct cros_gralloc_buffer_descriptor *descriptor,
 			 buffer_handle_t *out_handle);
 
@@ -54,6 +54,7 @@ class cros_gralloc_driver
 	{
 		return drv_kms_ != drv_render_;
 	};
+	bool IsSupportedYUVFormat(uint32_t droid_format);
 
       private:
 	cros_gralloc_driver(cros_gralloc_driver const &);

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -385,21 +385,8 @@ int32_t CrosGralloc1::allocate(struct cros_gralloc_buffer_descriptor *descriptor
 	uint64_t usage =
 	    cros_gralloc1_convert_usage(descriptor->producer_usage, descriptor->consumer_usage);
 	descriptor->use_flags = usage;
-	bool supported = driver->is_supported(descriptor);
-	if (!supported && (descriptor->consumer_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER)) {
-		/* when alloc BO_USE_SCANOUT buffer for kmsro, use BO_USE_SCANOUT for dev
-		 * dintinguish */
-		if (driver->is_kmsro_enabled() && (descriptor->use_flags & BO_USE_SCANOUT)) {
-			struct cros_gralloc_buffer_descriptor tmpdescriptor = *descriptor;
-			tmpdescriptor.use_flags &= ~BO_USE_SCANOUT;
-			supported = driver->is_supported(&tmpdescriptor);
-		} else {
-			descriptor->use_flags &= ~BO_USE_SCANOUT;
-			supported = driver->is_supported(descriptor);
-		}
-	}
 
-	if (!supported) {
+	if (!(driver->is_supported(descriptor))) {
 		drv_log("Unsupported combination -- HAL format: %u, HAL flags: %u, "
 			"drv_format: %u, drv_flags: %llu",
 			descriptor->droid_format, usage, descriptor->drm_format,

--- a/cros_gralloc/gralloc4/CrosGralloc4Allocator.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Allocator.cc
@@ -46,21 +46,7 @@ Error CrosGralloc4Allocator::allocate(const BufferDescriptorInfo& descriptor, ui
         return Error::UNSUPPORTED;
     }
 
-    bool supported = mDriver->is_supported(&crosDescriptor);
-    if (!supported && (descriptor.usage & BufferUsage::COMPOSER_OVERLAY)) {
-        /* when alloc BO_USE_SCANOUT buffer for kmsro, use BO_USE_SCANOUT for dev
-         * dintinguish */
-        if (mDriver->is_kmsro_enabled() && (crosDescriptor.use_flags & BO_USE_SCANOUT)) {
-            struct cros_gralloc_buffer_descriptor tmpDescriptor = crosDescriptor;
-            tmpDescriptor.use_flags &= ~BO_USE_SCANOUT;
-            supported = mDriver->is_supported(&tmpDescriptor);
-        } else {
-            crosDescriptor.use_flags &= ~BO_USE_SCANOUT;
-            supported = mDriver->is_supported(&crosDescriptor);
-        }
-    }
-
-    if (!supported) {
+    if (!(mDriver->is_supported(&crosDescriptor))) {
         std::string drmFormatString = getDrmFormatString(crosDescriptor.drm_format);
         std::string pixelFormatString = getPixelFormatString(descriptor.format);
         std::string usageString = getUsageString(descriptor.usage);

--- a/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
@@ -409,13 +409,7 @@ Return<void> CrosGralloc4Mapper::isSupported(const BufferDescriptorInfo& descrip
         return Void();
     }
 
-    bool supported = mDriver->is_supported(&crosDescriptor);
-    if (!supported) {
-        crosDescriptor.use_flags &= ~BO_USE_SCANOUT;
-        supported = mDriver->is_supported(&crosDescriptor);
-    }
-
-    hidlCb(Error::NONE, supported);
+    hidlCb(Error::NONE, mDriver->is_supported(&crosDescriptor));
     return Void();
 }
 


### PR DESCRIPTION
The video format have scanout flag but need use i915 driver
to allocate.

Tracked-On: OAM-101728
Signed-off-by: HeYue <yue.he@intel.com>