### PR TITLE
Alloc no-tile buffer when sriov mode

### DIFF
--- a/drv.c
+++ b/drv.c
@@ -180,14 +180,6 @@ struct driver *drv_create(int fd)
 	if (!drv->combos)
 		goto free_mappings;
 
-	if (drv->backend->init) {
-		ret = drv->backend->init(drv);
-		if (ret) {
-			drv_array_destroy(drv->combos);
-			goto free_mappings;
-		}
-	}
-
 	return drv;
 
 free_mappings:
@@ -199,6 +191,20 @@ free_lock:
 free_driver:
 	free(drv);
 	return NULL;
+}
+
+int drv_init(struct driver * drv, uint32_t grp_type)
+{
+	int ret = 0;
+	assert(drv);
+	assert(drv->backend);
+
+	drv->gpu_grp_type = grp_type;
+
+	if (drv->backend->init) {
+		ret = drv->backend->init(drv);
+	}
+	return ret;
 }
 
 void drv_destroy(struct driver *drv)

--- a/drv.h
+++ b/drv.h
@@ -117,6 +117,8 @@ struct mapping {
 
 struct driver *drv_create(int fd);
 
+int drv_init(struct driver * drv, uint32_t grp_type);
+
 void drv_destroy(struct driver *drv);
 
 int drv_get_fd(struct driver *drv);

--- a/drv_priv.h
+++ b/drv_priv.h
@@ -49,11 +49,20 @@ struct combination {
 	uint64_t use_flags;
 };
 
+enum CIV_GPU_TYPE {
+	ONE_GPU_INTEL = 1,
+	ONE_GPU_VIRTIO,
+	TWO_GPU_IGPU_VIRTIO,
+	TWO_GPU_IGPU_DGPU,
+	THREE_GPU_IGPU_VIRTIO_DGPU
+};
+
 struct driver {
 	int fd;
 	const struct backend *backend;
 	void *priv;
 	void *buffer_table;
+	uint32_t gpu_grp_type;  	// enum CIV_GPU_TYPE
 	struct drv_array *mappings;
 	struct drv_array *combos;
 	pthread_mutex_t driver_lock;

--- a/gbm.c
+++ b/gbm.c
@@ -62,6 +62,12 @@ PUBLIC struct gbm_device *gbm_create_device(int fd)
 		return NULL;
 	}
 
+	if (drv_init(gbm->drv, 0) != 0) {
+		drv_destroy(gbm->drv);
+		free(gbm);
+		return NULL;
+	}
+
 	return gbm;
 }
 

--- a/i915.c
+++ b/i915.c
@@ -144,6 +144,10 @@ static int i915_add_combinations(struct driver *drv)
 	if (i915->gen == 12)
 		scanout_and_render = unset_flags(scanout_and_render, BO_USE_SCANOUT);
 #endif
+	// In sriov mode, MMAP_GTT will fail for tiled buffer.
+	if ((drv->gpu_grp_type == TWO_GPU_IGPU_VIRTIO) || (drv->gpu_grp_type == THREE_GPU_IGPU_VIRTIO_DGPU))
+		scanout_and_render =
+			unset_flags(scanout_and_render, BO_USE_SW_READ_RARELY | BO_USE_SW_WRITE_RARELY);
 	drv_add_combinations(drv, render_formats, ARRAY_SIZE(render_formats), &metadata, render);
 	drv_add_combinations(drv, scanout_render_formats, ARRAY_SIZE(scanout_render_formats),
 			     &metadata, scanout_and_render);


### PR DESCRIPTION
When in sriov mode, MMAP_GTT will fail for tiled buffer. Only alloc no tile buffer for sriov to avoid potential map fail on tiled buffer. Tried with gfxbench, performance affect is not obvious.

Tracked-On: OAM-105096
Signed-off-by: chenyanxzhu <chenyanx.zhu@intel.com>