### PR TITLE
Fixed the validateBufferSize issue

### DIFF
--- a/cros_gralloc/cros_gralloc_helpers.cc
+++ b/cros_gralloc/cros_gralloc_helpers.cc
@@ -5,6 +5,8 @@
  */
 
 #include "cros_gralloc_helpers.h"
+#include <hardware/gralloc.h>
+#include "i915_private_android_types.h"
 
 #include <sync/sync.h>
 
@@ -31,6 +33,21 @@ bool is_flex_format(uint32_t format)
         return false;
 }
 #endif
+
+bool flex_format_match(uint32_t descriptor_format, uint32_t handle_format, uint64_t usage)
+{
+	bool flag = usage & (GRALLOC_USAGE_HW_CAMERA_READ | GRALLOC_USAGE_HW_CAMERA_WRITE);
+
+	/* HACK: See b/28671744 */
+	if (HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED == descriptor_format &&
+		((HAL_PIXEL_FORMAT_NV12 == handle_format && flag) ||
+		(HAL_PIXEL_FORMAT_RGBX_8888 == handle_format && !flag)))
+		return true;
+	else if (HAL_PIXEL_FORMAT_YCBCR_420_888 == descriptor_format && HAL_PIXEL_FORMAT_NV12 == handle_format)
+		return true;
+	else
+		return false;
+}
 
 uint32_t cros_gralloc_convert_format(int format)
 {

--- a/cros_gralloc/cros_gralloc_helpers.h
+++ b/cros_gralloc/cros_gralloc_helpers.h
@@ -24,6 +24,8 @@ cros_gralloc_handle_t cros_gralloc_convert_handle(buffer_handle_t handle);
 
 int32_t cros_gralloc_sync_wait(int32_t fence, bool close_fence);
 
+bool flex_format_match(uint32_t descriptor_format, uint32_t handle_format, uint64_t usage = 0);
+
 #ifdef USE_GRALLOC1
 int32_t cros_gralloc_sync_wait(int32_t acquire_fence);
 const char *drmFormat2Str(int format);

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -330,7 +330,8 @@ int32_t CrosGralloc1::validateBufferSize(buffer_handle_t buffer,
 		return CROS_GRALLOC_ERROR_BAD_HANDLE;
 	}
 
-	if (!is_flex_format(cros_gralloc_convert_format(descriptorInfo->format)) &&
+	if (!flex_format_match((uint32_t)descriptorInfo->format, (uint32_t)hnd->droid_format,
+		descriptorInfo->producerUsage | descriptorInfo->consumerUsage) &&
 	    cros_gralloc_convert_format(descriptorInfo->format) != hnd->format) {
 		return CROS_GRALLOC_ERROR_BAD_VALUE;
 	}

--- a/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
@@ -15,6 +15,7 @@
 
 #include "cros_gralloc/gralloc4/CrosGralloc4Utils.h"
 #include "helpers.h"
+#include "cros_gralloc/cros_gralloc_helpers.h"
 
 #ifdef USE_GRALLOC1
 #include "cros_gralloc/i915_private_android_types.h"
@@ -149,16 +150,9 @@ Return<Error> CrosGralloc4Mapper::validateBufferSize(void* rawHandle,
     }
 
     PixelFormat crosHandleFormat = static_cast<PixelFormat>(crosHandle->droid_format);
-#ifdef USE_GRALLOC1
-    int32_t yuvFormat = static_cast<int32_t>(descriptor.format);
-    if (descriptor.format != crosHandleFormat && yuvFormat != crosHandle->droid_format &&
-        !(descriptor.format == PixelFormat::YCBCR_420_888 &&
-            crosHandle->droid_format == HAL_PIXEL_FORMAT_NV12)) {
+    if (descriptor.format != crosHandleFormat &&
+        !flex_format_match((uint32_t)descriptor.format, (uint32_t)crosHandleFormat, descriptor.usage)) {
         drv_log("Failed to validateBufferSize. Format mismatch.\n");
-#else
-    if (descriptor.format != crosHandleFormat) {
-        drv_log("Failed to validateBufferSize. Format mismatch.\n");
-#endif
         return Error::BAD_BUFFER;
     }
 


### PR DESCRIPTION
when we use format HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED to allocate the buffer, we get the buffer with format DRM_FORMAT_XBGR8888. The validateBufferSize will return an error because format mismatch. So we should ignore this type.

Tracked-On: OAM-110999