### PR TITLE
INTERNAL: Adjust the condition to check KVM

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -142,7 +142,8 @@ static inline int vm_type()
 			sig.sig32[2] = edx;
 			if (!strncmp(sig.text, "ACRNACRNACRN", 12))
 				type |= HYPERTYPE_TYPE_ACRN;
-			else if (!strncmp(sig.text, "KVMKVMKVM", 9))
+			else if ((!strncmp(sig.text, "KVMKVMKVM", 9)) ||
+				 (!strncmp(sig.text, "EVMMEVMMEVMM", 12)))
 				type |= HYPERTYPE_TYPE_KVM;
 		}
 	}


### PR DESCRIPTION
The hypervisor signatures of kernel 5.10 and
5.15 are different.

Tracked-On: OAM-111639