### PR TITLE
Fix for no camera streams with tflite object detection app

### DIFF
--- a/cros_gralloc/mapper_stablec/Mapper.cpp
+++ b/cros_gralloc/mapper_stablec/Mapper.cpp
@@ -20,6 +20,8 @@
 #include "cros_gralloc/gralloc4/CrosGralloc4Metadata.h"
 #include "cros_gralloc/gralloc4/CrosGralloc4Utils.h"
 
+#include "cros_gralloc/i915_private_android_types.h"
+
 using namespace ::aidl::android::hardware::graphics::common;
 using namespace ::android::hardware::graphics::mapper;
 using ::aidl::android::hardware::graphics::allocator::BufferDescriptorInfo;
@@ -358,7 +360,9 @@ int32_t CrosGrallocMapperV5::getStandardMetadata(const cros_gralloc_buffer* cros
         return provide(1);
     }
     if constexpr (metadataType == StandardMetadataType::PIXEL_FORMAT_REQUESTED) {
-        return provide(static_cast<PixelFormat>(crosBuffer->get_android_format()));
+        int32_t format = crosBuffer->get_android_format();
+        return provide(static_cast<PixelFormat>(
+                       (format == HAL_PIXEL_FORMAT_NV12) ? HAL_PIXEL_FORMAT_YCbCr_420_888 : format));
     }
     if constexpr (metadataType == StandardMetadataType::PIXEL_FORMAT_FOURCC) {
         return provide(drv_get_standard_fourcc(crosBuffer->get_format()));


### PR DESCRIPTION
With tflite app, blank screen is seen instead of actual camera streams.

validateBufferSize in framework Gralloc5 code uses getStandardMetadata to query different parameters and validate it. Validation of format requested fails as created buffer format is not matching with the request format. In vendor aidl mapper, requested buffer format is mapped to private buffer format. On getStandardMetadata call, mapped private buffer format is returned instead of android known buffer format which results in validateBufferSize failure.

Fix the issue by returning android framework known buffer format instead of private format.

Tracked-On: OAM-111807