### PR TITLE
Remove the unnecessary error log.

### DIFF
--- a/cros_gralloc/gralloc4/CrosGralloc4Utils.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Utils.cc
@@ -454,7 +454,7 @@ int convertToCrosDescriptor(const BufferDescriptorInfo& descriptor,
 
     if (convertToDrmFormat(descriptor.format, &outCrosDescriptor->drm_format)) {
 #ifdef USE_GRALLOC1
-        drv_log("Failed to convert descriptor by convertToDrmFormat");
+        //drv_log("Failed to convert descriptor by convertToDrmFormat");
         if (!IsSupportedYUVFormat(static_cast<uint32_t>(descriptor.format))) {
             std::string pixelFormatString = getPixelFormatString(descriptor.format);
             drv_log("Failed to convert descriptor. Unsupported fomat %s\n", pixelFormatString.c_str());


### PR DESCRIPTION
This log is just reported the buffer format is not in upstream. but added by intel. such as YUV format.
It is not an error.

Tracked-On: OAM-112337