### PR TITLE
[SMR0] Fixed the issue that sw codec fails to validate 10-bit type buffer

### DIFF
--- a/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
@@ -150,7 +150,20 @@ Return<Error> CrosGralloc4Mapper::validateBufferSize(void* rawHandle,
     }
 
     PixelFormat crosHandleFormat = static_cast<PixelFormat>(crosHandle->droid_format);
-    if (descriptor.format != crosHandleFormat &&
+
+    uint32_t descriptor_drmFormat = 0, handle_drmFormat = 0;
+
+    if (convertToDrmFormat(descriptor.format, &descriptor_drmFormat)) {
+        drv_log("Failed to convertToDrmFormat, descriptor.format = %d", (uint32_t)descriptor.format);
+        return Error::BAD_VALUE;
+    }
+
+    if (convertToDrmFormat(crosHandleFormat, &handle_drmFormat)) {
+        drv_log("Failed to convertToDrmFormat, crosHandleFormat = %d", (uint32_t)crosHandleFormat);
+        return Error::BAD_VALUE;
+    }
+
+    if (descriptor_drmFormat  != handle_drmFormat  &&
         !flex_format_match((uint32_t)descriptor.format, (uint32_t)crosHandleFormat, descriptor.usage)) {
         drv_log("Failed to validateBufferSize. Format mismatch.\n");
         return Error::BAD_BUFFER;


### PR DESCRIPTION
The function validateBufferSize fails when sw codec allocates buffer with HAL_PIXEL_FORMAT_YCBCR_P010. The reason is that the pixel format will be converted to drm format for allocating buffer, then the format of the handle is assigned to HAL_PIXEL_ format type with i915_private_invert_format, but the descriptor.format is still the pixel format, they must be different when checked in validateBufferSize. So we check the format type after uniformly converting the pixel/HAL format to drm format.

Tracked-On: OAM-112372