### PR TITLE
Fix OAM-112477(Failed to boot android via ACRN)

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -20,7 +20,7 @@
 #endif
 
 // drv_render_ aim to open the render node
-cros_gralloc_driver::cros_gralloc_driver() : drv_render_(nullptr)
+cros_gralloc_driver::cros_gralloc_driver() : drv_kms_(nullptr), drv_render_(nullptr)
 {
 }
 
@@ -28,6 +28,16 @@ cros_gralloc_driver::~cros_gralloc_driver()
 {
 	buffers_.clear();
 	handles_.clear();
+
+	if (drv_kms_) {
+		int fd = drv_get_fd(drv_kms_);
+		drv_destroy(drv_kms_);
+		if (!is_kmsro_enabled()) {
+			drv_render_ = nullptr;
+		}
+		drv_kms_ = nullptr;
+		close(fd);
+	}
 
 	if (drv_render_) {
 		int fd = drv_get_fd(drv_render_);
@@ -63,19 +73,25 @@ int32_t cros_gralloc_driver::init()
 	int availabe_node = 0;
 	int virtio_node_idx = -1;
 	uint32_t gpu_grp_type = 0;
-
 	// destroy drivers if exist before re-initializing them
+	if (drv_kms_) {
+		int fd = drv_get_fd(drv_kms_);
+		drv_destroy(drv_kms_);
+		if (!is_kmsro_enabled()) {
+			drv_render_ = nullptr;
+		}
+		drv_kms_ = nullptr;
+		close(fd);
+	}
 	if (drv_render_) {
 		int fd = drv_get_fd(drv_render_);
 		drv_destroy(drv_render_);
 		drv_render_ = nullptr;
 		close(fd);
 	}
-
 	for (uint32_t i = min_node; i < max_node; i++) {
 		if (asprintf(&node, str, DRM_DIR_NAME, i) < 0)
 			continue;
-
 		fd = open(node, O_RDWR, 0);
 		free(node);
 		if (fd < 0)
@@ -109,7 +125,6 @@ int32_t cros_gralloc_driver::init()
 
 		drmFreeVersion(version);
 	}
-
 	// open the first render node
 	if (availabe_node > 0) {
 		drv_render_ = drv_create(node_fd[0]);
@@ -122,16 +137,25 @@ int32_t cros_gralloc_driver::init()
 		switch (availabe_node) {
 		// only have one render node, is GVT-d/BM/VirtIO
 		case 1:
-			if (!drv_render_)
+			if (drv_render_) {
+				drv_kms_ = drv_render_;
+			} else
 				goto fail;
 			gpu_grp_type = (virtio_node_idx != -1)? ONE_GPU_VIRTIO: ONE_GPU_INTEL;
 			break;
 		// is SR-IOV or iGPU + dGPU
 		case 2:
-			close(node_fd[1]);
 			if (virtio_node_idx != -1) {
+				drv_kms_ = drv_create(node_fd[virtio_node_idx]);
+				if (!drv_kms_) {
+					drv_log("Failed to create driver for virtio device\n");
+					close(node_fd[virtio_node_idx]);
+					goto fail;
+				}
 				gpu_grp_type = TWO_GPU_IGPU_VIRTIO;
 			} else {
+				close(node_fd[1]);
+				drv_kms_ = drv_render_;
 				gpu_grp_type = TWO_GPU_IGPU_DGPU;
 			}
 			break;
@@ -141,7 +165,12 @@ int32_t cros_gralloc_driver::init()
 				close(node_fd[1]);
 			}
 			if (virtio_node_idx != -1) {
-				close(node_fd[virtio_node_idx]);
+				drv_kms_ = drv_create(node_fd[virtio_node_idx]);
+				if (!drv_kms_) {
+					drv_log("Failed to create driver for virtio device\n");
+					close(node_fd[virtio_node_idx]);
+					goto fail;
+				}
 			}
 			gpu_grp_type = THREE_GPU_IGPU_VIRTIO_DGPU;
 			// TO-DO: the 3rd node is i915 or others.
@@ -154,14 +183,26 @@ int32_t cros_gralloc_driver::init()
 				goto fail;
 			}
 		}
+
+		if (drv_kms_ && (drv_kms_ != drv_render_)) {
+			if (drv_init(drv_kms_, gpu_grp_type)) {
+				drv_log("Failed to init kms driver\n");
+				goto fail;
+			}
+		}
 	}
-
-	if (!drv_render_)
+	if (!drv_render_ && !drv_kms_)
 		return -ENODEV;
-
 	return 0;
 
 fail:
+	if (drv_kms_) {
+		fd = drv_get_fd(drv_kms_);
+		drv_destroy(drv_kms_);
+		close(fd);
+		drv_kms_ = nullptr;
+	}
+
 	if (drv_render_) {
 		fd = drv_get_fd(drv_render_);
 		drv_destroy(drv_render_);
@@ -177,7 +218,7 @@ bool cros_gralloc_driver::is_supported(struct cros_gralloc_buffer_descriptor *de
 	struct combination *combo;
 	uint32_t resolved_format;
 	bool supported;
-	struct driver *drv = drv_render_;
+	struct driver *drv = (descriptor->use_flags & BO_USE_SCANOUT) ? drv_kms_ : drv_render_;
 
 	resolved_format = drv_resolve_format(drv, descriptor->drm_format, descriptor->use_flags);
 	combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
@@ -185,9 +226,24 @@ bool cros_gralloc_driver::is_supported(struct cros_gralloc_buffer_descriptor *de
 	supported = (combo != nullptr);
 
 	if (!supported && (descriptor->use_flags & BO_USE_SCANOUT)) {
-		descriptor->use_flags &= ~BO_USE_SCANOUT;
-		combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
+		if (is_kmsro_enabled()) {
+			/* if kmsro is enabled, it is scanout buffer and not used for video,
+			 * don't need remove scanout flag */
+			if (!IsSupportedYUVFormat(descriptor->droid_format)) {
+				combo = drv_get_combination(drv, resolved_format,
+                                            (descriptor->use_flags) & (~BO_USE_SCANOUT));
 				supported = (combo != nullptr);
+			} else {
+				drv = drv_render_;
+				descriptor->use_flags &= ~BO_USE_SCANOUT;
+				combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
+		                supported = (combo != nullptr);
+			}
+		} else {
+			descriptor->use_flags &= ~BO_USE_SCANOUT;
+			combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
+	                supported = (combo != nullptr);
+		}
 	}
 	return supported;
 }
@@ -227,12 +283,19 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	uint64_t use_flags;
 	int32_t reserved_region_fd;
 	char *name;
+	bool from_kms = false;
 
 	struct bo *bo;
 	struct cros_gralloc_handle *hnd;
 
 	struct driver *drv;
-	drv = drv_render_;
+
+	if ((descriptor->use_flags & BO_USE_SCANOUT)) {
+		from_kms = true;
+		drv = drv_kms_;
+	} else {
+		drv = drv_render_;
+	}
 
 	resolved_format = drv_resolve_format(drv, descriptor->drm_format, descriptor->use_flags);
 	use_flags = descriptor->use_flags;
@@ -309,7 +372,7 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	 * native_handle_delete().
 	 */
 	hnd = static_cast<struct cros_gralloc_handle *>(malloc(num_bytes));
-	hnd->from_kms = false; // not used, just set a default value. keep this member to be backward compatible.
+	hnd->from_kms = from_kms;
 	hnd->base.version = sizeof(hnd->base);
 	hnd->base.numFds = num_fds;
 	hnd->base.numInts = num_ints;
@@ -379,7 +442,7 @@ int32_t cros_gralloc_driver::retain(buffer_handle_t handle)
 		return -EINVAL;
 	}
 
-	drv = drv_render_;
+	drv = (hnd->from_kms) ? drv_kms_ : drv_render_;
 
 	auto buffer = get_buffer(hnd);
 	if (buffer) {
@@ -641,7 +704,7 @@ int32_t cros_gralloc_driver::get_reserved_region(buffer_handle_t handle,
 
 uint32_t cros_gralloc_driver::get_resolved_drm_format(uint32_t drm_format, uint64_t usage)
 {
-	struct driver *drv = drv_render_;
+	struct driver *drv = (usage & BO_USE_SCANOUT) ? drv_kms_ : drv_render_;
 
 	return drv_resolve_format(drv, drm_format, usage);
 }

--- a/cros_gralloc/cros_gralloc_driver.h
+++ b/cros_gralloc/cros_gralloc_driver.h
@@ -50,6 +50,10 @@ class cros_gralloc_driver
 
 	void for_each_handle(const std::function<void(cros_gralloc_handle_t)> &function);
 
+	bool is_kmsro_enabled()
+	{
+		return drv_kms_ != drv_render_;
+	};
 	bool IsSupportedYUVFormat(uint32_t droid_format);
 
       private:
@@ -57,6 +61,7 @@ class cros_gralloc_driver
 	cros_gralloc_driver operator=(cros_gralloc_driver const &);
 	cros_gralloc_buffer *get_buffer(cros_gralloc_handle_t hnd);
 
+	struct driver *drv_kms_;
 	struct driver *drv_render_;
 	std::mutex mutex_;
 	std::unordered_map<uint32_t, cros_gralloc_buffer *> buffers_;

--- a/i915.c
+++ b/i915.c
@@ -114,6 +114,17 @@ static uint64_t unset_flags(uint64_t current_flags, uint64_t mask)
 	return value;
 }
 
+/*
+ * Check if in virtual machine mode, by checking cpuid
+ */
+static inline bool is_in_vm()
+{
+	int ret;
+	uint32_t eax=0, ebx=0, ecx=0, edx=0;
+	ret = __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+	return ret && (((ecx >> 31) & 1) == 1);
+}
+
 static int i915_add_combinations(struct driver *drv)
 {
 	struct i915_device *i915 = drv->priv;
@@ -171,7 +182,10 @@ static int i915_add_combinations(struct driver *drv)
 
 	render = unset_flags(render, linear_mask | camera_mask);
 	scanout_and_render = unset_flags(scanout_and_render, linear_mask |camera_mask);
-	scanout_and_render = unset_flags(scanout_and_render, BO_USE_SCANOUT);
+
+	/* On ADL-P vm mode on 5.10 kernel, BO_USE_SCANOUT is not well supported for tiled bo */
+	if (is_in_vm() && i915->is_adlp)
+	    scanout_and_render = unset_flags(scanout_and_render, BO_USE_SCANOUT);
 
 	metadata.tiling = I915_TILING_X;
 	metadata.priority = 2;


### PR DESCRIPTION
1 Revert fdda46c2e975ecf3c72aa55af60fe19d0bf6fd89 to use virtio-gpu to allocate scanout buffer.
2 Use linear format for scanout buffer