### PR TITLE
Revert for using prev kernel

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.h
+++ b/cros_gralloc/cros_gralloc_driver.h
@@ -52,10 +52,6 @@ class cros_gralloc_driver
 
 	void for_each_handle(const std::function<void(cros_gralloc_handle_t)> &function);
 
-	bool is_kmsro_enabled()
-	{
-		return drv_kms_ != drv_render_;
-	};
 	bool IsSupportedYUVFormat(uint32_t droid_format);
 
       private:
@@ -63,7 +59,6 @@ class cros_gralloc_driver
 	cros_gralloc_driver operator=(cros_gralloc_driver const &);
 	cros_gralloc_buffer *get_buffer(cros_gralloc_handle_t hnd);
 
-	struct driver *drv_kms_;
 	struct driver *drv_render_;
 	std::mutex mutex_;
 	std::unordered_map<uint32_t, cros_gralloc_buffer *> buffers_;

--- a/i915.c
+++ b/i915.c
@@ -187,17 +187,6 @@ static uint64_t unset_flags(uint64_t current_flags, uint64_t mask)
 	return value;
 }
 
-/*
- * Check if in virtual machine mode, by checking cpuid
- */
-static inline bool is_in_vm()
-{
-	int ret;
-	uint32_t eax=0, ebx=0, ecx=0, edx=0;
-	ret = __get_cpuid(1, &eax, &ebx, &ecx, &edx);
-	return ret && (((ecx >> 31) & 1) == 1);
-}
-
 static int i915_add_combinations(struct driver *drv)
 {
 	struct i915_device *i915 = drv->priv;
@@ -255,10 +244,7 @@ static int i915_add_combinations(struct driver *drv)
 
 	render = unset_flags(render, linear_mask | camera_mask);
 	scanout_and_render = unset_flags(scanout_and_render, linear_mask |camera_mask);
-
-	/* On ADL-P vm mode on 5.10 kernel, BO_USE_SCANOUT is not well supported for tiled bo */
-	if (is_in_vm() && i915->is_adlp)
-	    scanout_and_render = unset_flags(scanout_and_render, BO_USE_SCANOUT);
+	scanout_and_render = unset_flags(scanout_and_render, BO_USE_SCANOUT);
 
 	/* On dGPU, only use linear */
 	if (i915->genx10 >= 125)

--- a/i915.c
+++ b/i915.c
@@ -187,11 +187,48 @@ static uint64_t unset_flags(uint64_t current_flags, uint64_t mask)
 	return value;
 }
 
+/*
+ * Check virtual machine type, by checking cpuid
+ */
+enum {
+	HYPERTYPE_NONE 	    = 0,
+	HYPERTYPE_ANY       = 0x1,
+	HYPERTYPE_TYPE_ACRN = 0x2,
+	HYPERTYPE_TYPE_KVM  = 0x4
+};
+static inline int vm_type()
+{
+	int type = HYPERTYPE_NONE;
+	union {
+		uint32_t sig32[3];
+		char text[13];
+	} sig = {};
+
+	uint32_t eax=0, ebx=0, ecx=0, edx=0;
+	if(__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
+		if (((ecx >> 31) & 1) == 1) {
+			type |= HYPERTYPE_ANY;
+
+			__cpuid(0x40000000U, eax, ebx, ecx, edx);
+			sig.sig32[0] = ebx;
+			sig.sig32[1] = ecx;
+			sig.sig32[2] = edx;
+			if (!strncmp(sig.text, "ACRNACRNACRN", 12))
+				type |= HYPERTYPE_TYPE_ACRN;
+			else if ((!strncmp(sig.text, "KVMKVMKVM", 9)) ||
+				 (!strncmp(sig.text, "EVMMEVMMEVMM", 12)))
+				type |= HYPERTYPE_TYPE_KVM;
+		}
+	}
+	return type;
+}
+
 static int i915_add_combinations(struct driver *drv)
 {
 	struct i915_device *i915 = drv->priv;
 	struct format_metadata metadata;
 	uint64_t render, scanout_and_render, texture_only;
+	bool is_kvm = vm_type() & HYPERTYPE_TYPE_KVM;
 
 	scanout_and_render = BO_USE_RENDER_MASK | BO_USE_SCANOUT;
 #ifdef USE_GRALLOC1
@@ -244,7 +281,11 @@ static int i915_add_combinations(struct driver *drv)
 
 	render = unset_flags(render, linear_mask | camera_mask);
 	scanout_and_render = unset_flags(scanout_and_render, linear_mask |camera_mask);
-	scanout_and_render = unset_flags(scanout_and_render, BO_USE_SCANOUT);
+
+	/* On ADL-P vm mode on 5.10 kernel, BO_USE_SCANOUT is not well supported for tiled bo */
+	if (is_kvm && i915->is_adlp) {
+	    scanout_and_render = unset_flags(scanout_and_render, BO_USE_SCANOUT);
+	}
 
 	/* On dGPU, only use linear */
 	if (i915->genx10 >= 125)


### PR DESCRIPTION
As the prelim kernel has been reverted to previous PKT kernel,
so scanout buffer allocation should be reverted to be using
i915, instead of virtio-gpu, and with tiling format instead of linear.