### PR TITLE
fix bo create failure when run with prelim kernel

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -860,7 +860,7 @@ static int i915_bo_create_from_metadata(struct bo *bo)
 	for (plane = 0; plane < bo->meta.num_planes; plane++)
 		bo->handles[plane].u32 = gem_handle;
 
-	if (i915_dev->genx10 != 125) {
+	if (!is_prelim_kernel && i915_dev->genx10 != 125) {
 		memset(&gem_set_tiling, 0, sizeof(gem_set_tiling));
 		gem_set_tiling.handle = bo->handles[0].u32;
 		gem_set_tiling.tiling_mode = bo->meta.tiling;
@@ -895,7 +895,7 @@ static int i915_bo_import(struct bo *bo, struct drv_import_fd_data *data)
 	if (ret)
 		return ret;
 
-	if (i915_dev->genx10 != 125) {
+	if (!is_prelim_kernel && i915_dev->genx10 != 125) {
 		/* TODO(gsingh): export modifiers and get rid of backdoor tiling. */
 		memset(&gem_get_tiling, 0, sizeof(gem_get_tiling));
 		gem_get_tiling.handle = bo->handles[0].u32;


### PR DESCRIPTION
It seems prelim kernel doesn't support set_tiling/get_tiling ioctl