### PR TITLE
Fixed codec format mismatch issue

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -448,6 +448,9 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	if (format == 0) {
 		format = descriptor->droid_format;
 	}
+	if ((hnd->format == DRM_FORMAT_NV12) && (descriptor->drm_format == DRM_FORMAT_FLEX_YCbCr_420_888)) {
+		format = HAL_PIXEL_FORMAT_YCbCr_420_888;
+	}
 	hnd->droid_format = format;
 	hnd->usage = descriptor->droid_usage;
 	hnd->total_size = descriptor->reserved_region_size + drv_bo_get_total_size(bo);

--- a/cros_gralloc/cros_gralloc_helpers.cc
+++ b/cros_gralloc/cros_gralloc_helpers.cc
@@ -134,7 +134,7 @@ uint32_t cros_gralloc_convert_format(int format)
 	case HAL_PIXEL_FORMAT_YCbCr_422_888:
 		return DRM_FORMAT_YUV422;
 	case HAL_PIXEL_FORMAT_P010_INTEL:
-		return DRM_FORMAT_P010;
+		return DRM_FORMAT_P010_INTEL;
 	}
 
 	return DRM_FORMAT_NONE;
@@ -287,67 +287,75 @@ std::string get_drm_format_string(uint32_t drm_format)
 int32_t cros_gralloc_invert_format(int format)
 {
        /* Convert the DRM FourCC into the most specific HAL pixel format. */
-       switch (format) {
-       case DRM_FORMAT_ARGB8888:
-               return HAL_PIXEL_FORMAT_BGRA_8888;
-       case DRM_FORMAT_RGB565:
-               return HAL_PIXEL_FORMAT_RGB_565;
-       case DRM_FORMAT_RGB888:
-               return HAL_PIXEL_FORMAT_RGB_888;
-       case DRM_FORMAT_ABGR8888:
-               return HAL_PIXEL_FORMAT_RGBA_8888;
-       case DRM_FORMAT_XBGR8888:
-               return HAL_PIXEL_FORMAT_RGBX_8888;
-       case DRM_FORMAT_FLEX_YCbCr_420_888:
-               return HAL_PIXEL_FORMAT_YCbCr_420_888;
-       case DRM_FORMAT_YVU420_ANDROID:
-               return HAL_PIXEL_FORMAT_YV12;
-       case DRM_FORMAT_R8:
-               return HAL_PIXEL_FORMAT_BLOB;
-       case DRM_FORMAT_NV12:
-               return HAL_PIXEL_FORMAT_NV12;
-       case DRM_FORMAT_NV12_Y_TILED_INTEL:
-               return HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL;
-       case DRM_FORMAT_YUYV:
-               return HAL_PIXEL_FORMAT_YCbCr_422_I;
-       case DRM_FORMAT_R16:
-               return HAL_PIXEL_FORMAT_Y16;
-       case DRM_FORMAT_P010:
-               return HAL_PIXEL_FORMAT_P010_INTEL;
-       case DRM_FORMAT_YUV444:
-               return HAL_PIXEL_FORMAT_YCbCr_444_888;
-       case DRM_FORMAT_NV21:
-               return HAL_PIXEL_FORMAT_YCrCb_420_SP;
-       case DRM_FORMAT_NV16:
-               return HAL_PIXEL_FORMAT_YCbCr_422_SP;
-       case DRM_FORMAT_YUV422:
-               return HAL_PIXEL_FORMAT_YCbCr_422_888;
-	   case DRM_FORMAT_ABGR16161616F:
-			   return HAL_PIXEL_FORMAT_RGBA_FP16;
-       default:
-               ALOGE("Unhandled DRM format %4.4s", drmFormat2Str(format));
-       }
-
-       return 0;
+	switch (format) {
+	case DRM_FORMAT_ARGB8888:
+		return HAL_PIXEL_FORMAT_BGRA_8888;
+	case DRM_FORMAT_RGB565:
+		return HAL_PIXEL_FORMAT_RGB_565;
+	case DRM_FORMAT_RGB888:
+		return HAL_PIXEL_FORMAT_RGB_888;
+	case DRM_FORMAT_ABGR8888:
+		return HAL_PIXEL_FORMAT_RGBA_8888;
+	case DRM_FORMAT_XBGR8888:
+		return HAL_PIXEL_FORMAT_RGBX_8888;
+	case DRM_FORMAT_FLEX_YCbCr_420_888:
+		return HAL_PIXEL_FORMAT_YCbCr_420_888;
+	case DRM_FORMAT_YVU420_ANDROID:
+		return HAL_PIXEL_FORMAT_YV12;
+	case DRM_FORMAT_R8:
+		return HAL_PIXEL_FORMAT_BLOB;
+	case DRM_FORMAT_NV12:
+		return HAL_PIXEL_FORMAT_NV12;
+	case DRM_FORMAT_NV12_Y_TILED_INTEL:
+		return HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL;
+	case DRM_FORMAT_YUYV:
+		return HAL_PIXEL_FORMAT_YCbCr_422_I;
+	case DRM_FORMAT_R16:
+		return HAL_PIXEL_FORMAT_Y16;
+	case DRM_FORMAT_P010_INTEL:
+		return HAL_PIXEL_FORMAT_P010_INTEL;
+	case DRM_FORMAT_YUV444:
+		return HAL_PIXEL_FORMAT_YCbCr_444_888;
+	case DRM_FORMAT_NV21:
+		return HAL_PIXEL_FORMAT_YCrCb_420_SP;
+	case DRM_FORMAT_NV16:
+		return HAL_PIXEL_FORMAT_YCbCr_422_SP;
+	case DRM_FORMAT_YUV422:
+		return HAL_PIXEL_FORMAT_YCbCr_422_888;
+	case DRM_FORMAT_ABGR16161616F:
+		return HAL_PIXEL_FORMAT_RGBA_FP16;
+	case DRM_FORMAT_ABGR2101010:
+		return HAL_PIXEL_FORMAT_RGBA_1010102;
+#if ANDROID_API_LEVEL >= 30
+	case DRM_FORMAT_P010:
+		return HAL_PIXEL_FORMAT_YCBCR_P010;
+#endif
+	default:
+		ALOGE("Unhandled DRM format %4.4s", drmFormat2Str(format));
+	}
+	return 0;
 }
 
 bool IsSupportedYUVFormat(uint32_t droid_format)
 {
-       switch (droid_format) {
-       case HAL_PIXEL_FORMAT_YCbCr_420_888:
-       case HAL_PIXEL_FORMAT_YV12:
-       case HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED:
-       case HAL_PIXEL_FORMAT_NV12:
-       case HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
-       case HAL_PIXEL_FORMAT_YCbCr_422_I:
-       case HAL_PIXEL_FORMAT_YCbCr_422_888:
-       case HAL_PIXEL_FORMAT_YCbCr_444_888:
-       case HAL_PIXEL_FORMAT_YCrCb_420_SP:
-       case HAL_PIXEL_FORMAT_Y16:
-       case HAL_PIXEL_FORMAT_P010_INTEL:
-               return true;
-       default:
-               return false;
-       }
-       return false;
+	switch (droid_format) {
+	case HAL_PIXEL_FORMAT_YCbCr_420_888:
+	case HAL_PIXEL_FORMAT_YV12:
+	case HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED:
+	case HAL_PIXEL_FORMAT_NV12:
+	case HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
+	case HAL_PIXEL_FORMAT_YCbCr_422_I:
+	case HAL_PIXEL_FORMAT_YCbCr_422_888:
+	case HAL_PIXEL_FORMAT_YCbCr_444_888:
+	case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+	case HAL_PIXEL_FORMAT_Y16:
+	case HAL_PIXEL_FORMAT_P010_INTEL:
+#if ANDROID_API_LEVEL >= 30
+	case HAL_PIXEL_FORMAT_YCBCR_P010:
+#endif
+		return true;
+	default:
+		return false;
+	}
+	return false;
 }

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -106,23 +106,26 @@ uint64_t cros_gralloc1_convert_map_usage(uint64_t producer_flags, uint64_t consu
 
 #ifdef USE_GRALLOC1
 bool IsSupportedYUVFormat(uint32_t droid_format) {
-   switch (droid_format) {
-       case HAL_PIXEL_FORMAT_YCbCr_420_888:
-       case HAL_PIXEL_FORMAT_YV12:
-       case HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED:
-       case HAL_PIXEL_FORMAT_NV12:
-       case HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
-       case HAL_PIXEL_FORMAT_YCbCr_422_I:
-       case HAL_PIXEL_FORMAT_YCbCr_422_888:
-       case HAL_PIXEL_FORMAT_YCbCr_444_888:
-       case HAL_PIXEL_FORMAT_YCrCb_420_SP:
-       case HAL_PIXEL_FORMAT_Y16:
-       case HAL_PIXEL_FORMAT_P010_INTEL:
-               return true;
-       default:
-               return false;
-       }
-       return false;
+	switch (droid_format) {
+	case HAL_PIXEL_FORMAT_YCbCr_420_888:
+	case HAL_PIXEL_FORMAT_YV12:
+	case HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED:
+	case HAL_PIXEL_FORMAT_NV12:
+	case HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
+	case HAL_PIXEL_FORMAT_YCbCr_422_I:
+	case HAL_PIXEL_FORMAT_YCbCr_422_888:
+	case HAL_PIXEL_FORMAT_YCbCr_444_888:
+	case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+	case HAL_PIXEL_FORMAT_Y16:
+	case HAL_PIXEL_FORMAT_P010_INTEL:
+#if ANDROID_API_LEVEL >= 30
+	case HAL_PIXEL_FORMAT_YCBCR_P010:
+#endif
+		return true;
+	default:
+		return false;
+	}
+	return false;
 }
 #endif
 
@@ -604,6 +607,7 @@ int32_t CrosGralloc1::lockYCbCr(buffer_handle_t bufferHandle,
 		ycbcr->chroma_step = 1;
 		break;
 	case DRM_FORMAT_P010:
+	case DRM_FORMAT_P010_INTEL:
 		ycbcr->y = addr[0];
 		ycbcr->cb = addr[1];
 		ycbcr->cr = addr[1] + 2;

--- a/cros_gralloc/gralloc4/CrosGralloc4Utils.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Utils.cc
@@ -296,6 +296,28 @@ const std::unordered_map<uint32_t, std::vector<PlaneLayout>>& GetPlaneLayoutsMap
                               .verticalSubsampling = 2,
                       }}},
 
+                    {DRM_FORMAT_P010_INTEL,
+                     {{
+                              .components = {{.type = android::gralloc4::PlaneLayoutComponentType_Y,
+                                              .offsetInBits = 6,
+                                              .sizeInBits = 10}},
+                              .sampleIncrementInBits = 16,
+                              .horizontalSubsampling = 1,
+                              .verticalSubsampling = 1,
+                      },
+                      {
+                              .components =
+                                      {{.type = android::gralloc4::PlaneLayoutComponentType_CB,
+                                        .offsetInBits = 6,
+                                        .sizeInBits = 10},
+                                       {.type = android::gralloc4::PlaneLayoutComponentType_CR,
+                                        .offsetInBits = 22,
+                                        .sizeInBits = 10}},
+                              .sampleIncrementInBits = 32,
+                              .horizontalSubsampling = 2,
+                              .verticalSubsampling = 2,
+                      }}},
+
                     {DRM_FORMAT_R8,
                      {{
                              .components = {{.type = android::gralloc4::PlaneLayoutComponentType_R,
@@ -441,24 +463,25 @@ int getPlaneLayouts(uint32_t drmFormat, std::vector<PlaneLayout>* outPlaneLayout
     return 0;
 }
 
-#ifdef USE_GRALLOC1
 bool IsSupportedYUVFormat(uint32_t droid_format) {
-   switch (droid_format) {
-       case HAL_PIXEL_FORMAT_YCbCr_420_888:
-       case HAL_PIXEL_FORMAT_YV12:
-       case HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED:
-       case HAL_PIXEL_FORMAT_NV12:
-       case HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
-       case HAL_PIXEL_FORMAT_YCbCr_422_I:
-       case HAL_PIXEL_FORMAT_YCbCr_422_888:
-       case HAL_PIXEL_FORMAT_YCbCr_444_888:
-       case HAL_PIXEL_FORMAT_YCrCb_420_SP:
-       case HAL_PIXEL_FORMAT_Y16:
-       case HAL_PIXEL_FORMAT_P010_INTEL:
-               return true;
-       default:
-               return false;
-       }
-       return false;
-}
+    switch (droid_format) {
+    case HAL_PIXEL_FORMAT_YCbCr_420_888:
+    case HAL_PIXEL_FORMAT_YV12:
+    case HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED:
+    case HAL_PIXEL_FORMAT_NV12:
+    case HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
+    case HAL_PIXEL_FORMAT_YCbCr_422_I:
+    case HAL_PIXEL_FORMAT_YCbCr_422_888:
+    case HAL_PIXEL_FORMAT_YCbCr_444_888:
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+    case HAL_PIXEL_FORMAT_Y16:
+    case HAL_PIXEL_FORMAT_P010_INTEL:
+#if ANDROID_API_LEVEL >= 30
+    case HAL_PIXEL_FORMAT_YCBCR_P010:
 #endif
+        return true;
+    default:
+        return false;
+    }
+    return false;
+}

--- a/cros_gralloc/mapper_stablec/Mapper.cpp
+++ b/cros_gralloc/mapper_stablec/Mapper.cpp
@@ -360,9 +360,7 @@ int32_t CrosGrallocMapperV5::getStandardMetadata(const cros_gralloc_buffer* cros
         return provide(1);
     }
     if constexpr (metadataType == StandardMetadataType::PIXEL_FORMAT_REQUESTED) {
-        int32_t format = crosBuffer->get_android_format();
-        return provide(static_cast<PixelFormat>(
-                       (format == HAL_PIXEL_FORMAT_NV12) ? HAL_PIXEL_FORMAT_YCbCr_420_888 : format));
+        return provide(static_cast<PixelFormat>(crosBuffer->get_android_format()));
     }
     if constexpr (metadataType == StandardMetadataType::PIXEL_FORMAT_FOURCC) {
         return provide(drv_get_standard_fourcc(crosBuffer->get_format()));

--- a/drv.h
+++ b/drv.h
@@ -101,6 +101,8 @@ extern "C" {
 
 #define DRM_FORMAT_NV12_Y_TILED_INTEL fourcc_code('9', '9', '9', '6')
 
+#define DRM_FORMAT_P010_INTEL fourcc_code('P', '0', '0', '9')
+
 //TODO: remove this defination once drm_fourcc.h contains it.
 #ifndef I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS
 #define I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS fourcc_mod_code(INTEL, 6)

--- a/drv_helpers.c
+++ b/drv_helpers.c
@@ -108,6 +108,7 @@ static const struct planar_layout *layout_from_format(uint32_t format)
 		return &biplanar_yuv_420_layout;
 
 	case DRM_FORMAT_P010:
+	case DRM_FORMAT_P010_INTEL:
 		return &biplanar_yuv_p010_layout;
 
 	case DRM_FORMAT_ABGR1555:
@@ -189,6 +190,7 @@ size_t drv_num_planes_from_format(uint32_t format)
                case DRM_FORMAT_NV12_Y_TILED_INTEL:
                case DRM_FORMAT_NV16:
                case DRM_FORMAT_P010:
+	       case DRM_FORMAT_P010_INTEL:
                        return 2;
                case DRM_FORMAT_YUV420:
                case DRM_FORMAT_YUV422:
@@ -377,6 +379,7 @@ int drv_dumb_bo_create_ex(struct bo *bo, uint32_t width, uint32_t height, uint32
 	case DRM_FORMAT_NV12:
 	case DRM_FORMAT_NV21:
 	case DRM_FORMAT_P010:
+	case DRM_FORMAT_P010_INTEL:
 		/* Adjust the height to include room for chroma planes */
 		aligned_height = 3 * DIV_ROUND_UP(height, 2);
 		break;

--- a/i915.c
+++ b/i915.c
@@ -44,7 +44,7 @@ static const uint32_t linear_source_formats[] = { DRM_FORMAT_R16,    DRM_FORMAT_
                                                  DRM_FORMAT_YUV444, DRM_FORMAT_NV21,
                                                  DRM_FORMAT_P010 };
 
-static const uint32_t source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_Y_TILED_INTEL };
+static const uint32_t source_formats[] = { DRM_FORMAT_P010_INTEL, DRM_FORMAT_NV12_Y_TILED_INTEL };
 
 struct iris_memregion {
 	struct drm_i915_gem_memory_class_instance region;
@@ -447,6 +447,7 @@ static int i915_add_combinations(struct driver *drv)
 #endif
 		drv_add_combination(drv, DRM_FORMAT_NV12, &metadata_4_tiled, nv12_usage);
 		drv_add_combination(drv, DRM_FORMAT_P010, &metadata_4_tiled, p010_usage);
+		drv_add_combination(drv, DRM_FORMAT_P010_INTEL, &metadata_4_tiled, p010_usage);
 		drv_add_combinations(drv, render_formats, ARRAY_SIZE(render_formats),
 				     &metadata_4_tiled, render_not_linear);
 		drv_add_combinations(drv, scanout_render_formats,
@@ -476,6 +477,7 @@ static int i915_add_combinations(struct driver *drv)
 #endif
 		drv_add_combination(drv, DRM_FORMAT_NV12, &metadata_y_tiled, nv12_usage);
 		drv_add_combination(drv, DRM_FORMAT_P010, &metadata_y_tiled, p010_usage);
+		drv_add_combination(drv, DRM_FORMAT_P010_INTEL, &metadata_y_tiled, p010_usage);
 		drv_add_combinations(drv, render_formats, ARRAY_SIZE(render_formats),
 				     &metadata_y_tiled, render_not_linear);
 		/* Y-tiled scanout isn't available on old platforms so we add


### PR DESCRIPTION
Refer to NV12 format, for P010,
sw render use:
HAL_PIXEL_FORMAT_YCBCR_P010 => DRM_FORMAT_P010
hw render use:
HAL_PIXEL_FORMAT_P010_INTEL => DRM_FORMAT_P010_INTEL

The HAL_PIXEL_FORMAT_YCBCR_420_888 convert to NV12 format to create bo. Add special check for it.

Tracked-On: OAM-118214