### PR TITLE
Remove check that fails mapping for tile 4

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -1257,8 +1257,7 @@ static void *i915_bo_map(struct bo *bo, struct vma *vma, uint32_t map_flags)
 	struct i915_device *i915 = bo->drv->priv;
 
 	if ((bo->meta.format_modifier == I915_FORMAT_MOD_Y_TILED_CCS) ||
-	    (bo->meta.format_modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS) ||
-	    (bo->meta.format_modifier == I915_FORMAT_MOD_4_TILED))
+	    (bo->meta.format_modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS))
 		return MAP_FAILED;
 
 	if (i915->has_mmap_offset) {


### PR DESCRIPTION
Check for tile 4 was causing bo_map to fail for avif format. Removing this check was previously causing failure for DRM_IOCTL_I915_GEM_MMAP_GTT.

As part of the dGPU support enablement patch 30ec0522, support for tile 4 has been added. Hence removing te check for tile 4 doesn't cause any failure.

Tracked-On: OAM-118420