### PR TITLE
Fix the format mismatch issue.

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -334,7 +334,6 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	uint64_t resolved_use_flags;
 	struct bo *bo;
 	struct cros_gralloc_handle *hnd;
-	int32_t format;
 	std::unique_ptr<cros_gralloc_buffer> buffer;
 
 	struct driver *drv;
@@ -444,14 +443,7 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	hnd->producer_usage = descriptor->producer_usage;
 	hnd->consumer_usage = descriptor->consumer_usage;
 #endif
-	format = cros_gralloc_invert_format(hnd->format);
-	if (format == 0) {
-		format = descriptor->droid_format;
-	}
-	if ((hnd->format == DRM_FORMAT_NV12) && (descriptor->drm_format == DRM_FORMAT_FLEX_YCbCr_420_888)) {
-		format = HAL_PIXEL_FORMAT_YCbCr_420_888;
-	}
-	hnd->droid_format = format;
+	hnd->droid_format = descriptor->droid_format;
 	hnd->usage = descriptor->droid_usage;
 	hnd->total_size = descriptor->reserved_region_size + drv_bo_get_total_size(bo);
 

--- a/cros_gralloc/cros_gralloc_helpers.cc
+++ b/cros_gralloc/cros_gralloc_helpers.cc
@@ -35,33 +35,6 @@ const char *drmFormat2Str(int drm_format)
 	return buf;
 }
 
-bool is_flex_format(uint32_t format)
-{
-	switch (format) {
-	case DRM_FORMAT_FLEX_IMPLEMENTATION_DEFINED:
-	case DRM_FORMAT_FLEX_YCbCr_420_888:
-		return true;
-	default:
-		return false;
-	}
-	return false;
-}
-
-bool flex_format_match(uint32_t descriptor_format, uint32_t handle_format, uint64_t usage)
-{
-	bool flag = usage & (GRALLOC_USAGE_HW_CAMERA_READ | GRALLOC_USAGE_HW_CAMERA_WRITE);
-
-	/* HACK: See b/28671744 */
-	if (HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED == descriptor_format &&
-		((HAL_PIXEL_FORMAT_NV12 == handle_format && flag) ||
-		(HAL_PIXEL_FORMAT_RGBX_8888 == handle_format && !flag)))
-		return true;
-	else if (HAL_PIXEL_FORMAT_YCBCR_420_888 == descriptor_format && HAL_PIXEL_FORMAT_NV12 == handle_format)
-		return true;
-	else
-		return false;
-}
-
 uint32_t cros_gralloc_convert_format(int format)
 {
 	/*
@@ -282,58 +255,6 @@ std::string get_drm_format_string(uint32_t drm_format)
 	char *sequence = (char *)&drm_format;
 	std::string s(sequence, 4);
 	return "DRM_FOURCC_" + s;
-}
-
-int32_t cros_gralloc_invert_format(int format)
-{
-       /* Convert the DRM FourCC into the most specific HAL pixel format. */
-	switch (format) {
-	case DRM_FORMAT_ARGB8888:
-		return HAL_PIXEL_FORMAT_BGRA_8888;
-	case DRM_FORMAT_RGB565:
-		return HAL_PIXEL_FORMAT_RGB_565;
-	case DRM_FORMAT_RGB888:
-		return HAL_PIXEL_FORMAT_RGB_888;
-	case DRM_FORMAT_ABGR8888:
-		return HAL_PIXEL_FORMAT_RGBA_8888;
-	case DRM_FORMAT_XBGR8888:
-		return HAL_PIXEL_FORMAT_RGBX_8888;
-	case DRM_FORMAT_FLEX_YCbCr_420_888:
-		return HAL_PIXEL_FORMAT_YCbCr_420_888;
-	case DRM_FORMAT_YVU420_ANDROID:
-		return HAL_PIXEL_FORMAT_YV12;
-	case DRM_FORMAT_R8:
-		return HAL_PIXEL_FORMAT_BLOB;
-	case DRM_FORMAT_NV12:
-		return HAL_PIXEL_FORMAT_NV12;
-	case DRM_FORMAT_NV12_Y_TILED_INTEL:
-		return HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL;
-	case DRM_FORMAT_YUYV:
-		return HAL_PIXEL_FORMAT_YCbCr_422_I;
-	case DRM_FORMAT_R16:
-		return HAL_PIXEL_FORMAT_Y16;
-	case DRM_FORMAT_P010_INTEL:
-		return HAL_PIXEL_FORMAT_P010_INTEL;
-	case DRM_FORMAT_YUV444:
-		return HAL_PIXEL_FORMAT_YCbCr_444_888;
-	case DRM_FORMAT_NV21:
-		return HAL_PIXEL_FORMAT_YCrCb_420_SP;
-	case DRM_FORMAT_NV16:
-		return HAL_PIXEL_FORMAT_YCbCr_422_SP;
-	case DRM_FORMAT_YUV422:
-		return HAL_PIXEL_FORMAT_YCbCr_422_888;
-	case DRM_FORMAT_ABGR16161616F:
-		return HAL_PIXEL_FORMAT_RGBA_FP16;
-	case DRM_FORMAT_ABGR2101010:
-		return HAL_PIXEL_FORMAT_RGBA_1010102;
-#if ANDROID_API_LEVEL >= 30
-	case DRM_FORMAT_P010:
-		return HAL_PIXEL_FORMAT_YCBCR_P010;
-#endif
-	default:
-		ALOGE("Unhandled DRM format %4.4s", drmFormat2Str(format));
-	}
-	return 0;
 }
 
 bool IsSupportedYUVFormat(uint32_t droid_format)

--- a/cros_gralloc/cros_gralloc_helpers.h
+++ b/cros_gralloc/cros_gralloc_helpers.h
@@ -54,8 +54,6 @@ cros_gralloc_handle_t cros_gralloc_convert_handle(buffer_handle_t handle);
 
 int32_t cros_gralloc_sync_wait(int32_t fence, bool close_fence);
 
-bool flex_format_match(uint32_t descriptor_format, uint32_t handle_format, uint64_t usage = 0);
-
 #ifdef USE_GRALLOC1
 int32_t cros_gralloc_sync_wait(int32_t acquire_fence);
 #endif
@@ -63,10 +61,6 @@ int32_t cros_gralloc_sync_wait(int32_t acquire_fence);
 std::string get_drm_format_string(uint32_t drm_format);
 
 const char *drmFormat2Str(int format);
-
-bool is_flex_format(uint32_t format);
-
-int32_t cros_gralloc_invert_format(int format);
 
 bool IsSupportedYUVFormat(uint32_t droid_format);
 #endif

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -319,9 +319,7 @@ int32_t CrosGralloc1::validateBufferSize(buffer_handle_t buffer,
 		return CROS_GRALLOC_ERROR_BAD_HANDLE;
 	}
 
-	if (!flex_format_match((uint32_t)descriptorInfo->format, (uint32_t)hnd->droid_format,
-		descriptorInfo->producerUsage | descriptorInfo->consumerUsage) &&
-	    cros_gralloc_convert_format(descriptorInfo->format) != hnd->format) {
+	if (descriptorInfo->format != hnd->droid_format) {
 		return CROS_GRALLOC_ERROR_BAD_VALUE;
 	}
 

--- a/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Mapper.cc
@@ -143,24 +143,11 @@ Return<Error> CrosGralloc4Mapper::validateBufferSize(void* rawHandle,
 
     PixelFormat crosHandleFormat = static_cast<PixelFormat>(crosHandle->droid_format);
 
-
-    uint32_t descriptor_drmFormat = 0, handle_drmFormat = 0;
-
-    if (convertToDrmFormat(descriptor.format, &descriptor_drmFormat)) {
-        ALOGE("Failed to convertToDrmFormat, descriptor.format = %d", (uint32_t)descriptor.format);
-        return Error::BAD_VALUE;
-    }
-
-    if (convertToDrmFormat(crosHandleFormat, &handle_drmFormat)) {
-        ALOGE("Failed to convertToDrmFormat, crosHandleFormat = %d", (uint32_t)crosHandleFormat);
-        return Error::BAD_VALUE;
-    }
-
-    if (descriptor_drmFormat  != handle_drmFormat  &&
-        !flex_format_match((uint32_t)descriptor.format, (uint32_t)crosHandleFormat, descriptor.usage)) {
+    if (descriptor.format != crosHandleFormat) {
         ALOGE("Failed to validateBufferSize. Format mismatch.");
         return Error::BAD_BUFFER;
     }
+
     if (descriptor.width != crosHandle->width) {
         ALOGE("Failed to validateBufferSize. Width mismatch (%d vs %d).", descriptor.width,
               crosHandle->width);


### PR DESCRIPTION
In minigbm, we convert the drm_format in function
drv_resolve_format_and_use_flags_helper to create bo. 
Do not invert bo.format as droid_format value.
This patch revert the comimit: https://github.com/projectceladon/minigbm/commit/0eeee785f7f59233db647e6dc408a859801a8f8e of Android Q.
With this patch, do not need this hardcode: https://github.com/projectceladon/minigbm/commit/a5ca9e4b8aabd0ab391be3d15f41a1cbef75ab31.

Tracked-On: OAM-118207