### PR TITLE
Fix android boot issue in SRIOV mode.

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -110,7 +110,6 @@ cros_gralloc_driver::cros_gralloc_driver()
 	int fd;
 	drmVersionPtr version;
 	const int render_num = 10;
-	const int name_length = 50;
 	int node_fd[render_num];
 	char *node_name[render_num] = {};
 	int availabe_node = 0;
@@ -122,6 +121,16 @@ cros_gralloc_driver::cros_gralloc_driver()
 	mt8183_camera_quirk_ = !strncmp(buf, "kukui", strlen("kukui"));
 
 	// destroy drivers if exist before re-initializing them
+	if (drv_kms_) {
+		int fd = drv_get_fd(drv_kms_);
+		drv_destroy(drv_kms_);
+		if (!is_kmsro_enabled()) {
+			drv_render_ = nullptr;
+		}
+		drv_kms_ = nullptr;
+		close(fd);
+	}
+
 	if (drv_render_) {
 		int fd = drv_get_fd(drv_render_);
 		drv_destroy(drv_render_);
@@ -175,42 +184,61 @@ cros_gralloc_driver::cros_gralloc_driver()
 		if (!drv_render_) {
 			drv_loge("Failed to create driver for the 1st device\n");
 			close(node_fd[0]);
-		}
-		switch (availabe_node) {
-		// only have one render node, is GVT-d/BM/VirtIO
-		case 1:
-			if (!drv_render_) {
-				fd = drv_get_fd(drv_render_);
-				drv_destroy(drv_render_);
-				close(fd);
-				drv_render_ = nullptr;
+		} else {
+			switch (availabe_node) {
+			// only have one render node, is GVT-d/BM/VirtIO
+			case 1:
+				if (drv_render_) {
+					drv_kms_ = drv_render_;
+				} else
+					break;
+				gpu_grp_type = (virtio_node_idx != -1)? ONE_GPU_VIRTIO: ONE_GPU_INTEL;
+				break;
+			// is SR-IOV or iGPU + dGPU
+			case 2:
+				if (virtio_node_idx != -1) {
+					drv_kms_ = drv_create(node_fd[virtio_node_idx]);
+					if (!drv_kms_) {
+						drv_loge("Failed to create driver for virtio device\n");
+						close(node_fd[virtio_node_idx]);
+						break;
+					}
+					gpu_grp_type = TWO_GPU_IGPU_VIRTIO;
+				} else {
+					close(node_fd[1]);
+					drv_kms_ = drv_render_;
+					gpu_grp_type = TWO_GPU_IGPU_DGPU;
+				}
+				break;
+			// is SR-IOV + dGPU
+			case 3:
+				if (!strcmp(node_name[1], "i915")) {
+					close(node_fd[1]);
+				}
+				if (virtio_node_idx != -1) {
+					drv_kms_ = drv_create(node_fd[virtio_node_idx]);
+					if (!drv_kms_) {
+						drv_loge("Failed to create driver for virtio device\n");
+						close(node_fd[virtio_node_idx]);
+						break;
+					}
+				}
+				gpu_grp_type = THREE_GPU_IGPU_VIRTIO_DGPU;
+				// TO-DO: the 3rd node is i915 or others.
+				break;
 			}
-			gpu_grp_type = (virtio_node_idx != -1)? ONE_GPU_VIRTIO: ONE_GPU_INTEL;
-			break;
-		// is SR-IOV or iGPU + dGPU
-		case 2:
-			close(node_fd[1]);
-			if (virtio_node_idx != -1) {
-				gpu_grp_type = TWO_GPU_IGPU_VIRTIO;
-			} else {
-				gpu_grp_type = TWO_GPU_IGPU_DGPU;
-			}
-			break;
-		// is SR-IOV + dGPU
-		case 3:
-			if (!strcmp(node_name[1], "i915")) {
-				close(node_fd[1]);
-			}
-			if (virtio_node_idx != -1) {
-				close(node_fd[virtio_node_idx]);
-			}
-			gpu_grp_type = THREE_GPU_IGPU_VIRTIO_DGPU;
-			// TO-DO: the 3rd node is i915 or others.
-			break;
-		}
 
-		if (drv_render_) {
-			drv_init(drv_render_, gpu_grp_type);
+			if (drv_render_) {
+				if (drv_init(drv_render_, gpu_grp_type)) {
+					drv_loge("Failed to init render driver\n");
+				}
+			}
+
+			if (drv_kms_ && (drv_kms_ != drv_render_)) {
+				if (drv_init(drv_kms_, gpu_grp_type)) {
+					drv_loge("Failed to init kms driver\n");
+				}
+			}
 		}
 	}
 
@@ -224,6 +252,16 @@ cros_gralloc_driver::~cros_gralloc_driver()
 	buffers_.clear();
 	handles_.clear();
 
+	if (drv_kms_) {
+		int fd = drv_get_fd(drv_kms_);
+		drv_destroy(drv_kms_);
+		if (!is_kmsro_enabled()) {
+			drv_render_ = nullptr;
+		}
+		drv_kms_ = nullptr;
+		close(fd);
+	}
+
 	if (drv_render_) {
 		int fd = drv_get_fd(drv_render_);
 		drv_destroy(drv_render_);
@@ -235,7 +273,7 @@ cros_gralloc_driver::~cros_gralloc_driver()
 
 bool cros_gralloc_driver::is_initialized()
 {
-	return (drv_render_ != nullptr);
+	return (drv_render_ != nullptr && drv_kms_ != nullptr);
 }
 
 bool cros_gralloc_driver::get_resolved_format_and_use_flags(
@@ -246,7 +284,7 @@ bool cros_gralloc_driver::get_resolved_format_and_use_flags(
 	uint64_t resolved_use_flags;
 	struct combination *combo;
 
-	struct driver *drv = drv_render_;
+	struct driver *drv = (descriptor->use_flags & BO_USE_SCANOUT) ? drv_kms_ : drv_render_;
 	if (mt8183_camera_quirk_ && (descriptor->use_flags & BO_USE_CAMERA_READ) &&
 	    !(descriptor->use_flags & BO_USE_SCANOUT) &&
 	    descriptor->drm_format == DRM_FORMAT_FLEX_IMPLEMENTATION_DEFINED) {
@@ -260,8 +298,21 @@ bool cros_gralloc_driver::get_resolved_format_and_use_flags(
 
 	combo = drv_get_combination(drv, resolved_format, resolved_use_flags);
 	if (!combo && (descriptor->use_flags & BO_USE_SCANOUT)) {
-		resolved_use_flags &= ~BO_USE_SCANOUT;
-		combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
+		if (is_kmsro_enabled()) {
+			/* if kmsro is enabled, it is scanout buffer and not used for video,
+			 * don't need remove scanout flag */
+			if (!IsSupportedYUVFormat(descriptor->droid_format)) {
+				combo = drv_get_combination(drv, resolved_format,
+					    (descriptor->use_flags) & (~BO_USE_SCANOUT));
+			} else {
+				drv = drv_render_;
+				resolved_use_flags &= ~BO_USE_SCANOUT;
+				combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
+			}
+		} else {
+			resolved_use_flags &= ~BO_USE_SCANOUT;
+			combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
+		}
 	}
 	if (!combo && (descriptor->droid_usage & GRALLOC_USAGE_HW_VIDEO_ENCODER) &&
 	    descriptor->droid_format != HAL_PIXEL_FORMAT_YCbCr_420_888) {
@@ -289,10 +340,11 @@ bool cros_gralloc_driver::is_supported(const struct cros_gralloc_buffer_descript
 {
 	uint32_t resolved_format;
 	uint64_t resolved_use_flags;
-	struct driver *drv = drv_render_;
+	struct driver *drv = (descriptor->use_flags & BO_USE_SCANOUT) ? drv_kms_ : drv_render_;
 	uint32_t max_texture_size = drv_get_max_texture_2d_size(drv);
 	if (!get_resolved_format_and_use_flags(descriptor, &resolved_format, &resolved_use_flags))
 		return false;
+
 	// Allow blob buffers to go beyond the limit.
 	if (descriptor->droid_format == HAL_PIXEL_FORMAT_BLOB)
 		return true;
@@ -335,10 +387,16 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	struct bo *bo;
 	struct cros_gralloc_handle *hnd;
 	std::unique_ptr<cros_gralloc_buffer> buffer;
+	bool from_kms = false;
 
 	struct driver *drv;
 
-	drv = drv_render_;
+        if ((descriptor->use_flags & BO_USE_SCANOUT)) {
+                from_kms = true;
+                drv = drv_kms_;
+        } else {
+                drv = drv_render_;
+        }
 
 	if (!get_resolved_format_and_use_flags(descriptor, &resolved_format, &resolved_use_flags)) {
 		ALOGE("Failed to resolve format and use_flags.");
@@ -402,7 +460,7 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 		hnd->fds[i] = -1;
 
 	hnd->num_planes = num_planes;
-	hnd->from_kms = false; // not used, just set a default value. keep this member to be backward compatible.
+	hnd->from_kms = from_kms;
 	for (size_t plane = 0; plane < num_planes; plane++) {
 		ret = drv_bo_get_plane_fd(bo, plane);
 		if (ret < 0)
@@ -488,7 +546,7 @@ int32_t cros_gralloc_driver::retain(buffer_handle_t handle)
 		return -EINVAL;
 	}
 
-	drv = drv_render_;
+	drv = (hnd->from_kms) ? drv_kms_ : drv_render_;
 
 	auto hnd_it = handles_.find(hnd);
 	if (hnd_it != handles_.end()) {
@@ -752,7 +810,7 @@ uint32_t cros_gralloc_driver::get_resolved_drm_format(uint32_t drm_format, uint6
 {
 	uint32_t resolved_format;
 	uint64_t resolved_use_flags;
-	struct driver *drv = drv_render_;
+	struct driver *drv = (use_flags & BO_USE_SCANOUT) ? drv_kms_ : drv_render_;
 
 	drv_resolve_format_and_use_flags(drv, drm_format, use_flags, &resolved_format,
 					 &resolved_use_flags);

--- a/cros_gralloc/cros_gralloc_driver.h
+++ b/cros_gralloc/cros_gralloc_driver.h
@@ -55,6 +55,10 @@ class cros_gralloc_driver
 			 const std::function<void(cros_gralloc_buffer *)> &function);
 	void with_each_buffer(const std::function<void(cros_gralloc_buffer *)> &function);
 	uint32_t get_resolved_common_drm_format(uint32_t drm_format);
+	bool is_kmsro_enabled()
+	{
+		return drv_kms_ != drv_render_;
+	};
 
       private:
 	cros_gralloc_driver();
@@ -83,6 +87,7 @@ class cros_gralloc_driver
 		int32_t refcount = 1;
 	};
 
+	struct driver *drv_kms_ = nullptr;
 	struct driver *drv_render_ = nullptr;
 	std::mutex mutex_;
 	std::unordered_map<uint32_t, std::unique_ptr<cros_gralloc_buffer>> buffers_;

--- a/drv.c
+++ b/drv.c
@@ -105,7 +105,6 @@ static const struct backend *drv_get_backend(int fd)
 struct driver *drv_create(int fd)
 {
 	struct driver *drv;
-	int ret;
 
 	drv = (struct driver *)calloc(1, sizeof(*drv));
 
@@ -140,14 +139,6 @@ struct driver *drv_create(int fd)
 	if (!drv->combos)
 		goto free_mappings;
 
-	if (drv->backend->init) {
-		ret = drv->backend->init(drv);
-		if (ret) {
-			drv_array_destroy(drv->combos);
-			goto free_mappings;
-		}
-	}
-
 	return drv;
 
 free_mappings:
@@ -163,13 +154,18 @@ free_driver:
 	return NULL;
 }
 
-void drv_init(struct driver * drv, uint32_t grp_type)
+int drv_init(struct driver * drv, uint32_t grp_type)
 {
 	int ret = 0;
 	assert(drv);
 	assert(drv->backend);
 
 	drv->gpu_grp_type = grp_type;
+
+	if (drv->backend->init) {
+		ret = drv->backend->init(drv);
+	}
+	return ret;
 }
 
 void drv_destroy(struct driver *drv)

--- a/drv.h
+++ b/drv.h
@@ -167,7 +167,7 @@ void drv_preload(bool load);
 
 struct driver *drv_create(int fd);
 
-void  drv_init(struct driver * drv, uint32_t grp_type);
+int drv_init(struct driver * drv, uint32_t grp_type);
 
 void drv_destroy(struct driver *drv);
 

--- a/gbm.c
+++ b/gbm.c
@@ -62,8 +62,6 @@ PUBLIC struct gbm_device *gbm_create_device(int fd)
 		return NULL;
 	}
 
-	drv_init(gbm->drv, 0);
-
 	return gbm;
 }
 


### PR DESCRIPTION
Following commits are reverted:
b5053aa2 Fix android VM boot issue
47523529 Remove drv_kms_
5d6cdab9 Refine the init function and fix issue

Reverting the above commits is equal to restoring minigbm to upstream code base.

Tests done:
- caas boot in GVT-d and SRIOV mode
- aaos boot in GVT-d and SRIOV mode
- Wi-Fi, Bluetooth on/off/connect/disconnect
- adb root
- adb remount

Tracked-On: