### PR TITLE
The graphic type should be set before driver init

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -210,7 +210,13 @@ cros_gralloc_driver::cros_gralloc_driver()
 		}
 
 		if (drv_render_) {
-			drv_init(drv_render_, gpu_grp_type);
+			if (drv_init(drv_render_, gpu_grp_type)) {
+				drv_loge("Failed to init driver\n");
+				fd = drv_get_fd(drv_render_);
+				drv_destroy(drv_render_);
+				close(fd);
+				drv_render_ = nullptr;
+			}
 		}
 	}
 

--- a/drv.c
+++ b/drv.c
@@ -140,14 +140,6 @@ struct driver *drv_create(int fd)
 	if (!drv->combos)
 		goto free_mappings;
 
-	if (drv->backend->init) {
-		ret = drv->backend->init(drv);
-		if (ret) {
-			drv_array_destroy(drv->combos);
-			goto free_mappings;
-		}
-	}
-
 	return drv;
 
 free_mappings:
@@ -163,13 +155,21 @@ free_driver:
 	return NULL;
 }
 
-void drv_init(struct driver * drv, uint32_t grp_type)
+int drv_init(struct driver * drv, uint32_t grp_type)
 {
 	int ret = 0;
 	assert(drv);
 	assert(drv->backend);
 
 	drv->gpu_grp_type = grp_type;
+	if (drv->backend->init) {
+		ret = drv->backend->init(drv);
+		if (ret) {
+			drv_array_destroy(drv->combos);
+			drv_array_destroy(drv->mappings);
+		}
+	}
+	return ret;
 }
 
 void drv_destroy(struct driver *drv)

--- a/drv.h
+++ b/drv.h
@@ -167,7 +167,7 @@ void drv_preload(bool load);
 
 struct driver *drv_create(int fd);
 
-void  drv_init(struct driver * drv, uint32_t grp_type);
+int drv_init(struct driver * drv, uint32_t grp_type);
 
 void drv_destroy(struct driver *drv);
 

--- a/gbm.c
+++ b/gbm.c
@@ -62,7 +62,11 @@ PUBLIC struct gbm_device *gbm_create_device(int fd)
 		return NULL;
 	}
 
-	drv_init(gbm->drv, 0);
+	if (drv_init(gbm->drv, 0) != 0) {
+		drv_destroy(gbm->drv);
+		free(gbm);
+		return NULL;
+	}
 
 	return gbm;
 }


### PR DESCRIPTION
This PR rever the commit b5053aa29930 as it casues the graphic type set fail.
Android VM boot fail if seperate the drv array init and drv init before. Now this issue not reproduced. So change it back.

Tracked-On: OAM-122333