### PR TITLE
Revert workaround after surface cpu_read optimization

### DIFF
--- a/drv.h
+++ b/drv.h
@@ -146,7 +146,6 @@ struct vma {
 	uint32_t map_flags;
 	int32_t refcount;
 	uint32_t map_strides[DRV_MAX_PLANES];
-	bool cpu;
 	void *priv;
 };
 

--- a/drv_helpers.c
+++ b/drv_helpers.c
@@ -522,10 +522,6 @@ void *drv_dumb_bo_map(struct bo *bo, struct vma *vma, uint32_t map_flags)
 
 int drv_bo_munmap(struct bo *bo, struct vma *vma)
 {
-	if (vma->cpu) {
-		free(vma->addr);
-		vma->addr = NULL;
-	}
 	return munmap(vma->addr, vma->length);
 }
 
@@ -618,44 +614,6 @@ bool drv_has_modifier(const uint64_t *list, uint32_t count, uint64_t modifier)
 	return false;
 }
 
-const u_int16_t ytile_width = 16;
-const u_int16_t ytile_heigth = 32;
-void one_ytile_to_linear(char *src, char *dst, u_int16_t x, u_int16_t y, u_int16_t width, u_int16_t height, uint32_t offset)
-{
-	// x and y follow linear
-	u_int32_t count = x + y * width/ytile_width;
-
-	for (int j = 0; j < ytile_width * ytile_heigth; j += ytile_width) {
-		memcpy(dst + offset + width * ytile_heigth * y + width * j / ytile_width + x * ytile_width,
-			src + offset + j + ytile_width * ytile_heigth * count, ytile_width);
-	}
-}
-
-void * ytiled_to_linear(struct bo_metadata meta, void * src)
-{
-	void* dst = malloc(meta.total_size);
-	if (NULL == dst) return NULL;
-
-	memset(dst, 0, meta.total_size);
-
-	u_int16_t height = meta.sizes[0] / meta.strides[0];
-	// Y
-	u_int16_t y_hcount =  height / ytile_heigth + (height % ytile_heigth != 0);
-	for (u_int16_t x = 0; x < meta.strides[0]/ytile_width; x++) {
-		for (u_int16_t y = 0; y < y_hcount; y++) {
-			one_ytile_to_linear(src, dst, x, y, meta.strides[0], height, 0);
-		}
-	}
-	// UV
-	u_int16_t uv_hcount =  (height/ytile_heigth/2) + (height % (ytile_heigth*2) != 0);
-	for (u_int16_t x = 0; x < meta.strides[0]/ytile_width; x++) {
-		for (u_int16_t y = 0; y < uv_hcount; y++) {
-			one_ytile_to_linear(src, dst, x, y, meta.strides[0], height/2, meta.sizes[0]);
-		}
-	}
-
-	return dst;
-}
 
 void drv_resolve_format_and_use_flags_helper(struct driver *drv, uint32_t format,
 					     uint64_t use_flags, uint32_t *out_format,

--- a/drv_helpers.h
+++ b/drv_helpers.h
@@ -10,9 +10,7 @@
 #include <stdbool.h>
 
 #include "drv.h"
-#include "drv_priv.h"
 #include "drv_array_helpers.h"
-#include <math.h>
 
 #ifndef PAGE_SIZE
 #define PAGE_SIZE 0x1000
@@ -51,8 +49,4 @@ bool drv_has_modifier(const uint64_t *list, uint32_t count, uint64_t modifier);
 void drv_resolve_format_and_use_flags_helper(struct driver *drv, uint32_t format,
 					     uint64_t use_flags, uint32_t *out_format,
 					     uint64_t *out_use_flags);
-
-void one_ytile_to_linear(char *src, char *dst, u_int16_t x, u_int16_t y,
-						u_int16_t width, u_int16_t height, uint32_t offset);
-void *ytiled_to_linear(struct bo_metadata meta, void * src);
 #endif

--- a/i915.c
+++ b/i915.c
@@ -1251,7 +1251,6 @@ static void *i915_bo_map(struct bo *bo, struct vma *vma, uint32_t map_flags)
 	int ret;
 	void *addr = MAP_FAILED;
 	struct i915_device *i915 = bo->drv->priv;
-	vma->cpu = false;
 
 	if ((bo->meta.format_modifier == I915_FORMAT_MOD_Y_TILED_CCS) ||
 	    (bo->meta.format_modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS))
@@ -1300,20 +1299,6 @@ static void *i915_bo_map(struct bo *bo, struct vma *vma, uint32_t map_flags)
 		/* And map it */
 		addr = mmap(0, bo->meta.total_size, PROT_READ | PROT_WRITE, MAP_SHARED, bo->drv->fd,
 			    mmap_arg.offset);
-
-		// TODO: GEM_MMAP_OFFSET cannot convert ytiled to linear, we have to convert it manually.
-		// Other formats(e.g. I915_TILING_X) should also be converted.
-		if ((bo->meta.use_flags & (BO_USE_SW_READ_OFTEN | BO_USE_SW_WRITE_OFTEN)) &&
-		    (bo->meta.tiling == I915_TILING_Y)) {
-			void* tmp_addr = ytiled_to_linear(bo->meta, addr);
-
-			if (NULL != tmp_addr) {
-				// release original one and replace it with a linear address.
-				munmap(addr, bo->meta.total_size);
-				addr = tmp_addr;
-				vma->cpu = true;
-			}
-		}
 	} else if (bo->meta.tiling == I915_TILING_NONE) {
 		struct drm_i915_gem_mmap gem_map = { 0 };
 		/* TODO(b/118799155): We don't seem to have a good way to


### PR DESCRIPTION
1. This is a revert for https://github.com/projectceladon/minigbm/pull/122
2. Releated to https://github.com/projectceladon/MediaSDK_C2/pull/179

Tracked-On: OAM-124403