### PR TITLE
Too many logs are seen in logcat

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -1295,8 +1295,10 @@ static void *i915_bo_map(struct bo *bo, struct vma *vma, uint32_t map_flags)
 			return MAP_FAILED;
 		}
 
-		drv_logi("%s : %d : handle = %x, size = %zd, mmpa_arg.offset = %llx", __func__,
-			__LINE__, mmap_arg.handle, bo->meta.total_size, mmap_arg.offset);
+		// Commenting this to prevent too many logging, it can be uncommented and used
+		// for debugging purpose.
+		//drv_logi("%s : %d : handle = %x, size = %zd, mmpa_arg.offset = %llx", __func__,
+		//	__LINE__, mmap_arg.handle, bo->meta.total_size, mmap_arg.offset);
 
 		/* And map it */
 		addr = mmap(0, bo->meta.total_size, PROT_READ | PROT_WRITE, MAP_SHARED, bo->drv->fd,


### PR DESCRIPTION
Removed that log to prevent flooding of logs.

Tracked-On: OAM-121425