### PR TITLE
[Do not merge] WA for VM3 screen cast

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.h
+++ b/cros_gralloc/cros_gralloc_driver.h
@@ -92,7 +92,6 @@ class cros_gralloc_driver
 	struct driver *drv_render_ = nullptr;
 	struct driver *drv_video_ = nullptr;
 	// the drv_kms_ is used to allocate scanout non-video buffer.
-	struct driver *drv_kms_ = nullptr;
 	struct driver *drv_ivshmem_ = nullptr;
 	uint32_t drv_num_ = 0;
 	uint64_t gpu_grp_type_ = GPU_TYPE_NORMAL;


### PR DESCRIPTION
The ivshm is deemed as kms in VM3 case.
Delete the kms as WA. Formal solution is
in investigation.