### PR TITLE
Add support the VM3 screen cast

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.h
+++ b/cros_gralloc/cros_gralloc_driver.h
@@ -92,7 +92,10 @@ class cros_gralloc_driver
 	struct driver *drv_render_ = nullptr;
 	struct driver *drv_video_ = nullptr;
 	// the drv_kms_ is used to allocate scanout non-video buffer.
+	// in dGPU/iGPU SRIOV, BM or dual GPU scenario, the drv_kms_ = drv_render_
 	struct driver *drv_kms_ = nullptr;
+	// the drv_ivshmem_ is used to allocate scanout buffer with
+	// certain resolution(screen cast).
 	struct driver *drv_ivshmem_ = nullptr;
 	uint32_t drv_num_ = 0;
 	uint64_t gpu_grp_type_ = GPU_TYPE_NORMAL;

--- a/drv.c
+++ b/drv.c
@@ -857,3 +857,15 @@ bool drv_virtgpu_is_ivshm(struct driver * drv)
         }
         return ret;
 }
+
+bool drv_is_dgpu(struct driver * drv)
+{
+	bool ret = false;
+	assert(drv);
+	assert(drv->backend);
+
+	if (drv->backend->is_dgpu) {
+		ret = drv->backend->is_dgpu(drv);
+	}
+	return ret;
+}

--- a/drv.h
+++ b/drv.h
@@ -254,6 +254,8 @@ bool drv_virtpci_with_blob(struct driver * drv);
 
 bool drv_virtgpu_is_ivshm(struct driver * drv);
 
+bool drv_is_dgpu(struct driver * drv);
+
 enum drv_log_level {
 	DRV_LOGV,
 	DRV_LOGD,

--- a/drv_priv.h
+++ b/drv_priv.h
@@ -108,6 +108,7 @@ struct backend {
 	uint32_t (*get_max_texture_2d_size)(struct driver *drv);
 	bool (*virtpci_with_blob)(struct driver *drv);
 	bool (*virtgpu_is_ivshm)(struct driver *drv);
+	bool (*is_dgpu)(struct driver *drv);
 };
 
 // clang-format off

--- a/i915.c
+++ b/i915.c
@@ -1429,6 +1429,12 @@ static int i915_bo_flush(struct bo *bo, struct mapping *mapping)
 	return 0;
 }
 
+static bool i915_is_dgpu(struct driver *drv)
+{
+	struct i915_device *i915 = drv->priv;
+	return i915->has_local_mem;
+}
+
 const struct backend backend_i915 = {
 	.name = "i915",
 	.init = i915_init,
@@ -1443,6 +1449,7 @@ const struct backend backend_i915 = {
 	.bo_flush = i915_bo_flush,
 	.resolve_format_and_use_flags = drv_resolve_format_and_use_flags_helper,
 	.num_planes_from_modifier = i915_num_planes_from_modifier,
+	.is_dgpu = i915_is_dgpu,
 };
 
 #endif

--- a/virtgpu_virgl.c
+++ b/virtgpu_virgl.c
@@ -1185,7 +1185,7 @@ static bool virgl_virtpci_with_blob(struct driver *drv) {
 
 static bool virgl_drv_virtgpu_is_ivshm(struct driver *drv) {
         struct virgl_priv *prv = (struct virgl_priv *)drv->priv;
-        return !(prv->dev_feature & VIRTGPU_PARAM_QUERY_DEV_BIT);
+        return (!(prv->dev_feature & VIRTGPU_PARAM_QUERY_DEV_BIT) && (prv->dev_feature & VIRTGPU_PARAM_RESOURCE_BLOB_BIT));
 }
 
 const struct backend virtgpu_virgl = { .name = "virtgpu_virgl",


### PR DESCRIPTION
VM3 dgpu passthrough, after probe ivshm, gralloc
will deem it as QNX case.
Check if the first render node is dGPU and
first virtiogpu is ivshm, it is dgpu + ivshm case.

Tracked-On: OAM-124710