### PR TITLE
Use dgpu for codec when dual gpu case

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -989,11 +989,11 @@ int cros_gralloc_driver::select_kms_driver(uint64_t gpu_grp_type)
 
 int cros_gralloc_driver::select_video_driver(uint64_t gpu_grp_type)
 {
-	if (gpu_grp_type & GPU_GRP_TYPE_HAS_INTEL_IGPU_BIT) {
-		return GPU_GRP_TYPE_INTEL_IGPU_IDX;
-	}
 	if (gpu_grp_type & GPU_GRP_TYPE_HAS_INTEL_DGPU_BIT) {
 		return GPU_GRP_TYPE_INTEL_DGPU_IDX;
+	}
+	if (gpu_grp_type & GPU_GRP_TYPE_HAS_INTEL_IGPU_BIT) {
+		return GPU_GRP_TYPE_INTEL_IGPU_IDX;
 	}
 	if (gpu_grp_type & GPU_GRP_TYPE_HAS_VIRTIO_GPU_BLOB_BIT) {
 		return GPU_GRP_TYPE_VIRTIO_GPU_BLOB_IDX;


### PR DESCRIPTION
Also, remove TILING_Y/TILING_4 support for render formats. TILING_Y/TILING_4 is for video only.

Tracked-On: OAM-128384