### PR TITLE
The hw protected buffer should be enable for widevine.

### DIFF
--- a/cros_gralloc/cros_gralloc_helpers.cc
+++ b/cros_gralloc/cros_gralloc_helpers.cc
@@ -147,7 +147,7 @@ uint64_t cros_gralloc_convert_usage(uint64_t usage)
 	 */
 	handle_usage(&usage, GRALLOC_USAGE_EXTERNAL_DISP, &use_flags, BO_USE_NONE);
 	/* Map PROTECTED to linear until real HW protection is available on Android. */
-	handle_usage(&usage, GRALLOC_USAGE_PROTECTED, &use_flags, BO_USE_LINEAR);
+	handle_usage(&usage, GRALLOC_USAGE_PROTECTED, &use_flags, BO_USE_PROTECTED);
 	handle_usage(&usage, GRALLOC_USAGE_CURSOR, &use_flags, BO_USE_NONE);
 	/* HACK: See b/30054495 for BO_USE_SW_READ_OFTEN. */
 	handle_usage(&usage, GRALLOC_USAGE_HW_VIDEO_ENCODER, &use_flags,

--- a/i915.c
+++ b/i915.c
@@ -332,7 +332,7 @@ static int i915_add_combinations(struct driver *drv)
 				     ARRAY_SIZE(scanout_render_formats), &metadata_4_tiled,
 				     render_not_linear);
                 drv_add_combinations(drv, source_formats, ARRAY_SIZE(source_formats), &metadata_4_tiled,
-                                     texture_flags | BO_USE_NON_GPU_HW);
+                                     texture_flags | BO_USE_NON_GPU_HW | hw_protected);
 
 	} else {
 		struct format_metadata metadata_y_tiled = { .tiling = I915_TILING_Y,
@@ -365,7 +365,7 @@ static int i915_add_combinations(struct driver *drv)
 				     ARRAY_SIZE(scanout_render_formats), &metadata_y_tiled,
 				     scanout_and_render_not_linear);
 		drv_add_combinations(drv, source_formats, ARRAY_SIZE(source_formats), &metadata_y_tiled,
-				     texture_flags | BO_USE_NON_GPU_HW);
+				     texture_flags | BO_USE_NON_GPU_HW | hw_protected);
 
 	}
 	return 0;
@@ -1040,6 +1040,24 @@ static int i915_bo_create_from_metadata(struct bo *bo)
 			}
 			gem_handle = gem_create_ext.handle;
 		}
+	} else if (i915->has_hw_protection && (bo->meta.use_flags & BO_USE_PROTECTED)) {
+		struct drm_i915_gem_create_ext_protected_content protected_content = {
+			.base = { .name = I915_GEM_CREATE_EXT_PROTECTED_CONTENT },
+			.flags = 0,
+		};
+		struct drm_i915_gem_create_ext gem_create_ext = {
+			.size = bo->meta.total_size,
+			.extensions = (uintptr_t)&protected_content,
+		};
+
+		ret = drmIoctl(bo->drv->fd, DRM_IOCTL_I915_GEM_CREATE_EXT, &gem_create_ext);
+		if (ret) {
+			drv_loge("DRM_IOCTL_I915_GEM_CREATE_EXT failed (size=%llu) (ret=%d) \n",
+				 gem_create_ext.size, ret);
+			return -errno;
+		}
+
+		gem_handle = gem_create_ext.handle;
 	} else {
 		struct drm_i915_gem_create gem_create;
 		memset(&gem_create, 0, sizeof(gem_create));


### PR DESCRIPTION
This PR rever the commit 30ec052 as it removed allocating protected buffer feature.

Android V need to supported widevine feature,So add it back.

Tracked-On: