### PR TITLE
minigbm: Add CCS support for render compression on MTL

### DIFF
--- a/drv.h
+++ b/drv.h
@@ -112,6 +112,21 @@ extern "C" {
 #ifndef I915_FORMAT_MOD_4_TILED
 #define I915_FORMAT_MOD_4_TILED         fourcc_mod_code(INTEL, 9)
 #endif
+
+#ifndef I915_FORMAT_MOD_4_TILED_MTL_RC_CCS
+//TODO: remove this defination once drm_fourcc.h contains it.
+/*
+ * Intel color control surfaces (CCS) for display ver 14 render compression.
+ *
+ * The main surface is tile4 and at plane index 0, the CCS is linear and
+ * at index 1. A 64B CCS cache line corresponds to an area of 4x1 tiles in
+ * main surface. In other words, 4 bits in CCS map to a main surface cache
+ * line pair. The main surface pitch is required to be a multiple of four
+ * tile4 widths.
+ */
+#define I915_FORMAT_MOD_4_TILED_MTL_RC_CCS fourcc_mod_code(INTEL, 13)
+#endif
+
 // clang-format on
 struct driver;
 struct bo;

--- a/i915.c
+++ b/i915.c
@@ -93,7 +93,8 @@ static const uint64_t gen12_modifier_order[] = { I915_FORMAT_MOD_Y_TILED_GEN12_R
 static const uint64_t gen11_modifier_order[] = { I915_FORMAT_MOD_Y_TILED, I915_FORMAT_MOD_X_TILED,
 						 DRM_FORMAT_MOD_LINEAR };
 
-static const uint64_t xe_lpdp_modifier_order[] = { I915_FORMAT_MOD_4_TILED, I915_FORMAT_MOD_X_TILED,
+static const uint64_t xe_lpdp_modifier_order[] = { I915_FORMAT_MOD_4_TILED_MTL_RC_CCS,
+						   I915_FORMAT_MOD_4_TILED, I915_FORMAT_MOD_X_TILED,
 						   DRM_FORMAT_MOD_LINEAR };
 
 struct modifier_support_t {
@@ -728,7 +729,8 @@ static size_t i915_num_planes_from_modifier(struct driver *drv, uint32_t format,
 {
 	size_t num_planes = drv_num_planes_from_format(format);
 	if (modifier == I915_FORMAT_MOD_Y_TILED_CCS ||
-	    modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS) {
+	    modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS ||
+	    modifier == I915_FORMAT_MOD_4_TILED_MTL_RC_CCS) {
 		assert(num_planes == 1);
 		return 2;
 	}
@@ -810,6 +812,7 @@ static int i915_bo_compute_metadata(struct bo *bo, uint32_t width, uint32_t heig
 		bo->meta.tiling = I915_TILING_Y;
 		break;
 	case I915_FORMAT_MOD_4_TILED:
+	case I915_FORMAT_MOD_4_TILED_MTL_RC_CCS:
 		bo->meta.tiling = I915_TILING_4;
 		break;
 	}
@@ -907,6 +910,38 @@ static int i915_bo_compute_metadata(struct bo *bo, uint32_t width, uint32_t heig
 		bo->meta.offsets[1] = bo->meta.sizes[0];
 		/* Total number of planes & sizes */
 		bo->meta.num_planes = i915_num_planes_from_modifier(bo->drv, format, modifier);
+		bo->meta.total_size = bo->meta.sizes[0] + bo->meta.sizes[1];
+	} else if (modifier == I915_FORMAT_MOD_4_TILED_MTL_RC_CCS) {
+
+		/*
+		 * considering only 128 byte compression and one cache line of
+		 * aux buffer(64B) contains compression status of 4-Y tiles.
+		 * Which is 4 * (128B * 32L).
+		 * line stride(bytes) is 4 * 128B
+		 * and tile stride(lines) is 32L
+		 */
+		uint32_t stride = ALIGN(drv_stride_from_format(format, width, 0), 512);
+		stride = ALIGN(stride, 256);
+
+		height = ALIGN(drv_height_from_format(format, height, 0), 32);
+
+		bo->meta.strides[0] = stride;
+		/* size calculation and alignment are 64KB aligned
+		 * size as per spec
+		 */
+		bo->meta.sizes[0] = ALIGN(stride * height, 65536);
+		bo->meta.offsets[0] = 0;
+
+		/* Aux buffer is linear and page aligned. It is placed after
+		 * other planes and aligned to main buffer stride.
+		 */
+		bo->meta.strides[1] = bo->meta.strides[0] / 8;
+
+		/* Aligned to page size */
+		bo->meta.sizes[1] = ALIGN(bo->meta.sizes[0] / 256, getpagesize());
+		bo->meta.offsets[1] = bo->meta.sizes[0];
+		/* Total number of planes & sizes */
+		bo->meta.num_planes = 2;
 		bo->meta.total_size = bo->meta.sizes[0] + bo->meta.sizes[1];
 	} else {
 		return i915_bo_from_format(bo, width, height, format);
@@ -1122,7 +1157,8 @@ static void *i915_bo_map(struct bo *bo, struct vma *vma, uint32_t map_flags)
 	struct i915_device *i915 = bo->drv->priv;
 
 	if ((bo->meta.format_modifier == I915_FORMAT_MOD_Y_TILED_CCS) ||
-	    (bo->meta.format_modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS))
+	    (bo->meta.format_modifier == I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS) ||
+	    (bo->meta.format_modifier == I915_FORMAT_MOD_4_TILED_MTL_RC_CCS))
 		return MAP_FAILED;
 
 	if (i915->has_mmap_offset) {


### PR DESCRIPTION
BUG=b:201620358
TEST=boot chromeos with UI with I915_FORMAT_MOD_4_TILED_MTL_RC_CCS modifier success
     cat /sys/kernel/debug/dri/0/i915_gem_framebuffer
     [PLANE:31:plane 1A]: type=PRI
		uapi: [FB:286] XR24 little-endian (0x34325258),0x10000000000000d,1920x1200, visible=visible, src=1920.000000x1200.000000+0.000000+0.000000, dst=1920x1200+0+0, rotation=0 (0x00000001)
		hw: [FB:286] XR24 little-endian (0x34325258),0x10000000000000d,1920x1200, visible=yes, src=1920.000000x1200.000000+0.000000+0.000000, dst=1920x1200+0+0, rotation=0 (0x00000001)

Tracked-On: OAM-129537
Change-Id: I78d961265576de7b9871d56c727654651659af32

Reviewed-on: https://chromium-review.googlesource.com/c/chromiumos/platform/minigbm/+/4569893
Reviewed-by: Dominik Behr <dbehr@chromium.org>
Reviewed-by: Sachin Kumar <sachin.kumar@intel.com>
Commit-Queue: Sachin Kumar <sachin.kumar@intel.com>
Tested-by: K Konda Reddy <k.konda.reddy@intel.com>