### PR TITLE
Use dgpu for codec when dual gpu case

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -989,11 +989,11 @@ int cros_gralloc_driver::select_kms_driver(uint64_t gpu_grp_type)
 
 int cros_gralloc_driver::select_video_driver(uint64_t gpu_grp_type)
 {
-	if (gpu_grp_type & GPU_GRP_TYPE_HAS_INTEL_IGPU_BIT) {
-		return GPU_GRP_TYPE_INTEL_IGPU_IDX;
-	}
 	if (gpu_grp_type & GPU_GRP_TYPE_HAS_INTEL_DGPU_BIT) {
 		return GPU_GRP_TYPE_INTEL_DGPU_IDX;
+	}
+	if (gpu_grp_type & GPU_GRP_TYPE_HAS_INTEL_IGPU_BIT) {
+		return GPU_GRP_TYPE_INTEL_IGPU_IDX;
 	}
 	if (gpu_grp_type & GPU_GRP_TYPE_HAS_VIRTIO_GPU_BLOB_BIT) {
 		return GPU_GRP_TYPE_VIRTIO_GPU_BLOB_IDX;


### PR DESCRIPTION
Also, remove TILING_Y/TILING_4 support for render formats in hybrid gpu mode. iGPU doesn't support TILING_4, dGPU doesn't support TILING_Y. When TILING_Y memory alloc by iGPU, but composite or display by dGPU, there will be blur screen issue.

Do clflush when write often, otherwise it'll affect antutu video decoding score. In this case, the buffer content is not changed. So no need to write back.

Tracked-On: OAM-129621