### PR TITLE
minigbm: Use clflushopt if supported

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -163,6 +163,7 @@ cc_library_shared {
         "-Wno-cast-qual",
         "-Wno-unused-function",
         "-DHAVE_MEMFD_CREATE",
+        "-mclflushopt",
     ],
     enabled: false,
     local_include_dirs: [

--- a/i915.c
+++ b/i915.c
@@ -447,9 +447,14 @@ static void i915_clflush(void *start, size_t size)
 
 	__builtin_ia32_mfence();
 	while (p < end) {
+#if defined(__CLFLUSHOPT__)
+		__builtin_ia32_clflushopt(p);
+#else
 		__builtin_ia32_clflush(p);
+#endif
 		p = (void *)((uintptr_t)p + I915_CACHELINE_SIZE);
 	}
+	__builtin_ia32_mfence();
 }
 
 static int gem_param(int fd, int name)


### PR DESCRIPTION
Use clflushopt if it is supported instead of clflush. clflushopt is more optimized and suggested by the HW engineers. It has improved MTL unmap operation times significantly.

BUG=b:274641129
TEST=camera preview should be minimum of 30fps

Tracked-On: OAM-129962


Change-Id: I9bf7e355d5ebdfb1647c578173123bb73db5571d
Reviewed-on: https://chromium-review.googlesource.com/c/chromiumos/platform/minigbm/+/4382538
Reviewed-by: Dominik Behr <dbehr@chromium.org>