### PR TITLE
Rename DRM_FORMAT_NV12_Y_TILED_INTEL

### DIFF
--- a/cros_gralloc/cros_gralloc_helpers.cc
+++ b/cros_gralloc/cros_gralloc_helpers.cc
@@ -95,7 +95,7 @@ uint32_t cros_gralloc_convert_format(int format)
 	case HAL_PIXEL_FORMAT_NV12:
 		return DRM_FORMAT_NV12;
 	case HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
-		return DRM_FORMAT_NV12_Y_TILED_INTEL;
+		return DRM_FORMAT_NV12_INTEL;
 	case HAL_PIXEL_FORMAT_YCbCr_422_I:
 		return DRM_FORMAT_YUYV;
 	case HAL_PIXEL_FORMAT_YCbCr_444_888:

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -587,7 +587,7 @@ int32_t CrosGralloc1::lockYCbCr(buffer_handle_t bufferHandle,
 
 	switch (hnd->format) {
 	case DRM_FORMAT_NV12:
-	case DRM_FORMAT_NV12_Y_TILED_INTEL:
+	case DRM_FORMAT_NV12_INTEL:
 		ycbcr->y = addr[0];
 		ycbcr->cb = addr[1];
 		ycbcr->cr = addr[1] + 1;

--- a/cros_gralloc/gralloc4/CrosGralloc4Utils.cc
+++ b/cros_gralloc/gralloc4/CrosGralloc4Utils.cc
@@ -252,7 +252,7 @@ const std::unordered_map<uint32_t, std::vector<PlaneLayout>>& GetPlaneLayoutsMap
                               .verticalSubsampling = 2,
                       }}},
 
-                    {DRM_FORMAT_NV12_Y_TILED_INTEL,
+                    {DRM_FORMAT_NV12_INTEL,
                      {{
                               .components = {{.type = android::gralloc4::PlaneLayoutComponentType_Y,
                                               .offsetInBits = 0,

--- a/drv.c
+++ b/drv.c
@@ -747,7 +747,7 @@ uint32_t drv_resolved_common_drm_format(uint32_t format)
 {
 	uint32_t ret = format;
 	switch (format) {
-		case DRM_FORMAT_NV12_Y_TILED_INTEL:
+		case DRM_FORMAT_NV12_INTEL:
 		case DRM_FORMAT_FLEX_YCbCr_420_888:
 		case DRM_FORMAT_FLEX_IMPLEMENTATION_DEFINED:
 			ret = DRM_FORMAT_NV12;

--- a/drv.h
+++ b/drv.h
@@ -99,7 +99,7 @@ extern "C" {
 #define I915_FORMAT_MOD_4_TILED	fourcc_mod_code(INTEL, 9)
 #define I915_TILING_4		9
 
-#define DRM_FORMAT_NV12_Y_TILED_INTEL fourcc_code('9', '9', '9', '6')
+#define DRM_FORMAT_NV12_INTEL fourcc_code('9', '9', '9', '6')
 
 #define DRM_FORMAT_P010_INTEL fourcc_code('P', '0', '0', '9')
 

--- a/drv_helpers.c
+++ b/drv_helpers.c
@@ -104,7 +104,7 @@ static const struct planar_layout *layout_from_format(uint32_t format)
 
 	case DRM_FORMAT_NV12:
 	case DRM_FORMAT_NV21:
-	case DRM_FORMAT_NV12_Y_TILED_INTEL:
+	case DRM_FORMAT_NV12_INTEL:
 		return &biplanar_yuv_420_layout;
 
 	case DRM_FORMAT_P010:
@@ -187,7 +187,7 @@ size_t drv_num_planes_from_format(uint32_t format)
                switch (format) {
                case DRM_FORMAT_R16:
                        return 1;
-               case DRM_FORMAT_NV12_Y_TILED_INTEL:
+               case DRM_FORMAT_NV12_INTEL:
                case DRM_FORMAT_NV16:
                case DRM_FORMAT_P010:
 	       case DRM_FORMAT_P010_INTEL:

--- a/i915.c
+++ b/i915.c
@@ -48,7 +48,7 @@ static const uint32_t linear_source_formats[] = { DRM_FORMAT_R16,    DRM_FORMAT_
                                                  DRM_FORMAT_YUV444, DRM_FORMAT_NV21,
                                                  DRM_FORMAT_P010 };
 
-static const uint32_t source_formats[] = { DRM_FORMAT_P010_INTEL, DRM_FORMAT_NV12_Y_TILED_INTEL };
+static const uint32_t source_formats[] = { DRM_FORMAT_P010_INTEL, DRM_FORMAT_NV12_INTEL };
 
 struct iris_memregion {
 	struct drm_i915_gem_memory_class_instance region;

--- a/xe.c
+++ b/xe.c
@@ -40,7 +40,7 @@ static const uint32_t linear_source_formats[] = { DRM_FORMAT_R16,    DRM_FORMAT_
                                                  DRM_FORMAT_YUV444, DRM_FORMAT_NV21,
                                                  DRM_FORMAT_P010 };
 
-static const uint32_t source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_Y_TILED_INTEL };
+static const uint32_t source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_INTEL };
 
 #if !defined(DRM_CAP_CURSOR_WIDTH)
 #define DRM_CAP_CURSOR_WIDTH 0x8


### PR DESCRIPTION
Replace DRM_FORMAT_NV12_Y_TILED_INTEL with a more common name DRM_FORMAT_NV12_INTEL.

Tracked-On: OAM-129537