### PR TITLE
Support GPU_DATA_BUFFER usage for RGBA8888

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -267,7 +267,8 @@ static int i915_add_combinations(struct driver *drv)
 			       BO_USE_CAMERA_READ | BO_USE_CAMERA_WRITE | BO_USE_HW_VIDEO_DECODER |
 				   BO_USE_HW_VIDEO_ENCODER | BO_USE_GPU_DATA_BUFFER |
 				   BO_USE_SENSOR_DIRECT_DATA);
-       drv_modify_combination(drv, DRM_FORMAT_ABGR8888, &metadata_linear, BO_USE_CURSOR | BO_USE_SCANOUT);
+       drv_modify_combination(drv, DRM_FORMAT_ABGR8888, &metadata_linear, BO_USE_CURSOR | BO_USE_SCANOUT |
+                                   BO_USE_GPU_DATA_BUFFER);
        drv_modify_combination(drv, DRM_FORMAT_NV12, &metadata_linear,
                               BO_USE_RENDERING | BO_USE_TEXTURE | BO_USE_CAMERA_MASK);
        drv_modify_combination(drv, DRM_FORMAT_YUYV, &metadata_linear,


### PR DESCRIPTION
To fix CtsDeqpTestCases rgba8888 related error.

Tracked-On: OAM-130657