### PR TITLE
Fix fps low for video play on multi 4k screens

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -914,9 +914,16 @@ static int i915_bo_compute_metadata(struct bo *bo, uint32_t width, uint32_t heig
 	return 0;
 }
 
-static bool is_need_local(int64_t use_flags, uint64_t gpu_grp_type)
+static bool is_need_local(int64_t use_flags, uint64_t gpu_grp_type, uint32_t format)
 {
 	static bool local = false;
+
+        for (uint32_t i = 0; i < sizeof(source_formats) / sizeof(source_formats[0]); i++) {
+                if (source_formats[i] == format) {
+                        local = true;
+                        return local;
+                }
+        }
 
 	if (use_flags & BO_USE_LOCAL_MEMORY) {
 		local = true;
@@ -953,7 +960,7 @@ static int i915_bo_create_from_metadata(struct bo *bo)
 	struct drm_i915_gem_set_tiling gem_set_tiling = { 0 };
 	struct i915_device *i915 = bo->drv->priv;
 	int64_t use_flags = bo->meta.use_flags;
-	bool local = is_need_local(use_flags, bo->drv->gpu_grp_type);
+	bool local = is_need_local(use_flags, bo->drv->gpu_grp_type, bo->meta.format);
 
 	if (local && i915->has_local_mem) {
 		if (!is_prelim_kernel) {


### PR DESCRIPTION
When control the multi-screen by scrcpy, instead of local screen touch, the codec bo alloc request will contain VIDEO_ENCODER flag. This flag will affect i915 to use legacy allocation, which will not include local memory. And when SF use dgpu for composition, it'll take much longer time.
This fix needs co-work with setting player to use dgpu/local mem in Settings.

Tracked-On: OAM-130002