### PR TITLE
[Android14] Fix memory crash in screencap

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -313,8 +313,8 @@ restart:
 
 cros_gralloc_driver::~cros_gralloc_driver()
 {
-	buffers_.clear();
 	handles_.clear();
+	buffers_.clear();
 	if (gpu_grp_type_ == 0) {
 		DRV_DESTROY(drv_fallback_);
 		return;


### PR DESCRIPTION
Raw pointers in handles_ may point to buffers_, so buffers_ must be cleared after handles_ to avoid use-after-free.

Tracked-On: OAM-131884