### PR TITLE
Fix ARL scrcpy issue

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -268,7 +268,7 @@ static int i915_add_combinations(struct driver *drv)
 				   BO_USE_HW_VIDEO_ENCODER | BO_USE_GPU_DATA_BUFFER |
 				   BO_USE_SENSOR_DIRECT_DATA);
        drv_modify_combination(drv, DRM_FORMAT_ABGR8888, &metadata_linear, BO_USE_CURSOR | BO_USE_SCANOUT |
-                                   BO_USE_GPU_DATA_BUFFER);
+                                   BO_USE_GPU_DATA_BUFFER | BO_USE_HW_VIDEO_ENCODER);
        drv_modify_combination(drv, DRM_FORMAT_NV12, &metadata_linear,
                               BO_USE_RENDERING | BO_USE_TEXTURE | BO_USE_CAMERA_MASK);
        drv_modify_combination(drv, DRM_FORMAT_YUYV, &metadata_linear,


### PR DESCRIPTION
The ARL use i915 backend, add the AB24 VIDEO_ENCODER flag support

Tracked-On: OAM-134179